### PR TITLE
Fix longer passwords, remove hard coded default password

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -224,6 +224,10 @@ config APP_WEB_TERMINAL
 	select BASE64
 	select MBEDTLS_SHA1
 
+config DEFAULT_ADMIN_PASSWORD
+	string "Default admin password"
+	default "admin"
+
 config SYSTEM_WORKQUEUE_STACK_SIZE
 	int
 	depends on HTTP_SERVER_WEBSOCKET

--- a/Kconfig
+++ b/Kconfig
@@ -191,6 +191,10 @@ config REDFISH_SYSTEM_MEMORY_GIB
 	help
 	  Total system memory in GiB for Redfish MemorySummary. 0 shows as N/A.
 
+config HTTP_SERVER_MAX_HEADER_LEN
+	int
+	default 48 # Basic auth header + 15 character password is 34 characters
+
 endif # REDFISH
 
 config HTTP_SERVER_NUM_SERVICES

--- a/Kconfig
+++ b/Kconfig
@@ -226,7 +226,7 @@ config APP_WEB_TERMINAL
 
 config DEFAULT_ADMIN_PASSWORD
 	string "Default admin password"
-	default "admin"
+	default "$(shell,openssl rand -base64 12 | head -c 15)"
 
 config SYSTEM_WORKQUEUE_STACK_SIZE
 	int

--- a/src/config.c
+++ b/src/config.c
@@ -566,6 +566,11 @@ int config_bmc_password_set(const char *password)
 {
 	int rc;
 
+	if (strlen(password) > MAX_PW_LEN) {
+		LOG_ERR("Password too long, max length is %d characters", MAX_PW_LEN);
+		return -EINVAL;
+	}
+
 	strlcpy(config_data.bmc_admin_password, password, sizeof(config_data.bmc_admin_password));
 	rc = config_write_str(CFG_BMC_ADMIN_PASSWORD, config_data.bmc_admin_password);
 	if (rc < 0) {
@@ -582,6 +587,8 @@ int config_bmc_password_set(const char *password)
 
 static int cmd_config_bmc_password(const struct shell *sh, size_t argc, char **argv)
 {
+	int rc;
+
 	ARG_UNUSED(argc);
 
 	if (!is_boot_finished()) {
@@ -589,7 +596,12 @@ static int cmd_config_bmc_password(const struct shell *sh, size_t argc, char **a
 		return -EAGAIN;
 	}
 
-	config_bmc_password_set(argv[1]);
+	rc = config_bmc_password_set(argv[1]);
+	if (rc) {
+		shell_error(sh, "Could not set BMC admin password (err=%d)", rc);
+		return rc;
+	}
+
 	shell_info(sh, "BMC admin password updated");
 
 	return 0;

--- a/src/config.c
+++ b/src/config.c
@@ -62,6 +62,8 @@ struct config_data {
 	uint32_t bmc_default_ip4_gw;
 };
 
+BUILD_ASSERT(strlen(CONFIG_DEFAULT_ADMIN_PASSWORD) <= MAX_PW_LEN);
+
 static struct config_data config_data;
 
 /*
@@ -758,7 +760,7 @@ int config_init(void)
 	 */
 	rc = config_read_str(CFG_BMC_ADMIN_PASSWORD, config_data.bmc_admin_password);
 	if (rc < 0) {
-		strlcpy(config_data.bmc_admin_password, "admin", sizeof(config_data.bmc_admin_password));
+		strlcpy(config_data.bmc_admin_password, CONFIG_DEFAULT_ADMIN_PASSWORD, sizeof(config_data.bmc_admin_password));
 		config_write_str(CFG_BMC_ADMIN_PASSWORD, config_data.bmc_admin_password);
 	}
 

--- a/static_web_resources/index.html
+++ b/static_web_resources/index.html
@@ -381,7 +381,8 @@
 				<div class="grid-4-col">
 					<div class="info-item">
 						<label for="cfg-password">New Password</label>
-						<input type="password" id="cfg-password" placeholder="Unchanged">
+						<input type="password" id="cfg-password" placeholder="Unchanged" title="Maximum 15 characters">
+						<small id="pwd-error" style="color: red; display: none;">Password must be 15 characters or fewer.</small>
 					</div>
 				</div>
 
@@ -836,6 +837,16 @@
 				alert(`Failed: ${err.message}`);
 			}
 		}
+
+		// Show password error if password is too long
+		document.getElementById('cfg-password').addEventListener('input', function (e) {
+			const errEl = document.getElementById('pwd-error');
+			if (e.target.value.length > 15) {
+				errEl.style.display = 'inline';
+			} else {
+				errEl.style.display = 'none';
+			}
+		});
 
 		// --- Terminal Handling ---
 		let term = null;

--- a/static_web_resources/index.html
+++ b/static_web_resources/index.html
@@ -309,7 +309,7 @@
 				<img src="logo.jpeg" alt="WallaBMC" style="max-width: 200px; height: auto;">
 			</div>
 			<form class="login-form" onsubmit="event.preventDefault(); connectToBmc();">
-				<input type="password" id="password" placeholder="Password (default: 'admin')" autofocus>
+				<input type="password" id="password" placeholder="Password" autofocus>
 				<button type="submit">Login</button>
 			</form>
 			<p id="login-error" style="text-align: center; color: var(--danger); margin-top: 15px;" class="hidden"></p>


### PR DESCRIPTION
Fix HTTP authentication with passwords > 13 characters.

Remove the hard coded default password.

Replace it with a password in `.config`. If it's unset a random password is generated.

Show a warning in the web UI if trying to set a too long password.

Fail setting a too long password.