### PR TITLE
Fix and tidy crypto

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -33,60 +33,60 @@ config MAIN_STACK_SIZE
 
 config APP_CRYPTO
 	bool
+	select NET_SOCKETS_SOCKOPT_TLS
 	select MBEDTLS
 	select MBEDTLS_ENABLE_HEAP
-	select NET_SOCKETS_SOCKOPT_TLS
-	select TLS_CREDENTIALS
-	select PSA_WANT_ALG_ECDH
-	select PSA_WANT_ALG_ECDSA
-	select PSA_WANT_ECC_SECP_R1_256
-	select PSA_WANT_ECC_SECP_R1_384
-	select PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY
-	select PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT
-	select PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT
-	select PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE
-	select MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
-	select PSA_WANT_ALG_CCM
-	select PSA_WANT_ALG_GCM
-	select MBEDTLS_PK_WRITE_C
-	select PSA_WANT_ALG_TLS12_PRF
-	select PSA_WANT_ALG_SHA_1
-	select PSA_WANT_ALG_SHA_256
-	select PSA_WANT_ALG_SHA_384
-	select PSA_CRYPTO
-	select PSA_WANT_ALG_CHACHA20_POLY1305
-	select PSA_WANT_KEY_TYPE_CHACHA20
-# TLS1.3
+	select MBEDTLS_SSL_PROTO_TLS1_2
+	select MBEDTLS_SSL_ALPN
+	# XXX: Should HAVE_TIME_DATE be enabled? Test if it prevents HTTPS
+	# connections if the RTC is wrong, in which case it might not be
+	# feasible if we need webui to set time.
+	# select MBEDTLS_HAVE_TIME_DATE if RTC
+
+config APP_CRYPTO_TLS13
+	bool
+	default y
+	depends on APP_CRYPTO && !APP_CRYPTO_PSK
 	select MBEDTLS_SSL_PROTO_TLS1_3
-	select MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
-	select PSA_CRYPTO_ENABLE_ALL
+        select MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
+	select MBEDTLS_SSL_EARLY_DATA
+        select MBEDTLS_SSL_SESSION_TICKETS
 	select PSA_WANT_ALG_HKDF
 	select PSA_WANT_ALG_HKDF_EXTRACT
 	select PSA_WANT_ALG_HKDF_EXPAND
-	select MBEDTLS_USE_PSA_CRYPTO
-	select MBEDTLS_PSA_CRYPTO_C
-	select MBEDTLS_ECP_C
-	select MBEDTLS_ECDH_C
-	select MBEDTLS_ECDSA_C
-	select MBEDTLS_HMAC_DRBG_C
-	select MBEDTLS_CTR_DRBG_C
-	select MBEDTLS_HKDF_C
-	select MBEDTLS_MAC_SHA256_ENABLED
-	select MBEDTLS_MAC_SHA384_ENABLED
-	select MBEDTLS_CIPHER_CCM_ENABLED
-	select MBEDTLS_CIPHER_GCM_ENABLED
-	select MBEDTLS_CHACHA20_ENABLED
-	select MBEDTLS_POLY1305_ENABLED
-	select MBEDTLS_CHACHA20_POLY1305_ENABLED
-	select MBEDTLS_ECP_DP_SECP256R1_ENABLED
-	select MBEDTLS_ECDSA_DETERMINISTIC
-	select MBEDTLS_SSL_ALPN
+
+config APP_CRYPTO_PUBLIC_KEY
+	bool
+	# Basic ciphers
+	select MBEDTLS_CIPHERSUITE_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+	select PSA_WANT_ALG_SHA_256
+	# Plus SHA384
+	select PSA_WANT_ALG_SHA_384
+	# Plus CHACHA20
+	select PSA_WANT_ALG_CHACHA20_POLY1305
+	select PSA_WANT_KEY_TYPE_CHACHA20
+	# Required for websocket
+	select PSA_WANT_ALG_SHA_1 if HTTP_SERVER_WEBSOCKET
+
+# PSK can only use TLS1.2 (supporting 1.3 seems to require pulling in
+# so much that it is not worthwhile).
+config APP_CRYPTO_PSK
+	bool
+	select MBEDTLS_KEY_EXCHANGE_PSK_ENABLED # TLS1.2
+	select MBEDTLS_CIPHERSUITE_TLS_PSK_WITH_AES_128_GCM_SHA256
+	select MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED
+	select MBEDTLS_RSA_C
+	select MBEDTLS_PKCS1_V15
+	select PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT
+	select PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT
+	select PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE
 
 config APP_CRYPTO_DEBUG
-	bool
+	bool "crypto debug"
 	default n
 	select MBEDTLS_DEBUG
 	select MBEDTLS_MEMORY_DEBUG
+	select NET_SOCKETS_TLS_LOG_LEVEL_DBG
 
 config MBEDTLS_DEBUG_LEVEL
 	int
@@ -135,11 +135,23 @@ config MBEDTLS_SSL_MAX_CONTENT_LEN
 	default 4096
 
 config APP_HTTPS
-	bool "HTTPS supprot for web and redfish"
+	bool "HTTPS support for web and redfish"
 	default y
 	depends on REDFISH || APP_WEB
 	select HTTP_SERVER_TLS_USE_ALPN
 	select APP_CRYPTO
+
+config APP_HTTPS_PUBLIC_KEY
+	bool "HTTPS public key support"
+	default y
+	depends on APP_HTTPS
+	select APP_CRYPTO_PUBLIC_KEY
+
+config APP_HTTPS_PSK
+	bool "HTTPS PSK support"
+	default n
+	depends on APP_HTTPS
+	select APP_CRYPTO_PSK
 
 config REDFISH
 	bool "Redfish server"
@@ -204,6 +216,9 @@ config APP_WEB_TERMINAL
 	select SHELL_BACKEND_WEBSOCKET
 	select LOG_BACKEND_WS
 	select LOG_BACKEND_WS_AUTOSTART
+	# WS auth protocol requires these hashes
+	select BASE64
+	select MBEDTLS_SHA1
 
 config SYSTEM_WORKQUEUE_STACK_SIZE
 	int

--- a/src/certificate.h
+++ b/src/certificate.h
@@ -8,11 +8,7 @@
 #ifndef __CERTIFICATE_H__
 #define __CERTIFICATE_H__
 
-enum tls_tag {
-        /** Used for both the public and private server keys */
-        HTTP_SERVER_CERTIFICATE_TAG,
-};
-
+#if defined(CONFIG_APP_HTTPS_PUBLIC_KEY)
 static const unsigned char server_certificate[] = {
 #include "server_cert.der.inc"
 };
@@ -21,5 +17,6 @@ static const unsigned char server_certificate[] = {
 static const unsigned char private_key[] = {
 #include "server_privkey.der.inc"
 };
+#endif
 
 #endif /* __CERTIFICATE_H__ */

--- a/src/config.c
+++ b/src/config.c
@@ -110,6 +110,21 @@ const char *config_bmc_ntp_server(void)
 	return config_data.bmc_ntp_server;
 }
 
+#if defined(CONFIG_APP_HTTPS_PSK)
+/*
+ * This is a placeholder to test PSK. If we want to support it
+ * properly it would have to be configurable.
+ */
+bool config_bmc_https_psk(const char **psk, int *psk_len)
+{
+	static const char p[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, };
+
+	*psk = p;
+	*psk_len = sizeof(p);
+	return true;
+}
+#endif
+
 int config_bmc_hostname_set(const char *hostname)
 {
 	int rc;

--- a/src/config.h
+++ b/src/config.h
@@ -23,4 +23,5 @@ int config_bmc_use_dhcp4_set(bool use);
 bool config_host_auto_poweron(void);
 int config_host_auto_poweron_set(bool on);
 const char *config_bmc_admin_password(void);
+bool config_bmc_https_psk(const char **psk, int *psk_len);
 #endif

--- a/src/http.c
+++ b/src/http.c
@@ -32,11 +32,34 @@ DEFINE_WEBSOCKET_SERVICE(http_service);
 #endif
 
 #if defined(CONFIG_APP_HTTPS)
+
 #include "certificate.h"
 
+#ifndef CONFIG_NET_SOCKETS_SOCKOPT_TLS
+#error "CONFIG_NET_SOCKETS_SOCKOPT_TLS=n"
+#endif
+
+#if defined(CONFIG_APP_HTTPS_PSK)
+#ifndef CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
+#error "CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED=n"
+#endif
+#endif
+
+enum tls_tag {
+#if defined(CONFIG_APP_HTTPS_PUBLIC_KEY)
+        /** Used for both the public and private server keys */
+        HTTP_SERVER_CERTIFICATE_TAG,
+#endif
+#if defined(CONFIG_APP_HTTPS_PSK)
+        PSK_TAG,
+#endif
+};
+
 static const sec_tag_t sec_tag_list_verify_none[] = {
+#if defined(CONFIG_APP_HTTPS_PUBLIC_KEY)
 		HTTP_SERVER_CERTIFICATE_TAG,
-#if defined(CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED)
+#endif
+#if defined(CONFIG_APP_HTTPS_PSK)
 		PSK_TAG,
 #endif
 	};
@@ -54,7 +77,7 @@ static int setup_tls(void)
 {
 	int err = 0;
 
-#if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)
+#if defined(CONFIG_APP_HTTPS_PUBLIC_KEY)
 	err = tls_credential_add(HTTP_SERVER_CERTIFICATE_TAG,
 				 TLS_CREDENTIAL_PUBLIC_CERTIFICATE,
 				 server_certificate,
@@ -71,27 +94,33 @@ static int setup_tls(void)
 		LOG_ERR("Failed to register private key: %d", err);
 		return err;
 	}
+#endif
 
-#if defined(CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED)
-	err = tls_credential_add(PSK_TAG,
-				 TLS_CREDENTIAL_PSK,
-				 psk,
-				 sizeof(psk));
-	if (err < 0) {
-		LOG_ERR("Failed to register PSK: %d", err);
-		return err;
-	}
+#if defined(CONFIG_APP_HTTPS_PSK)
+	const char *psk;
+	int psk_len;
+	if (config_bmc_https_psk(&psk, &psk_len)) {
+		err = tls_credential_add(PSK_TAG,
+					 TLS_CREDENTIAL_PSK,
+					 psk,
+					 psk_len);
+		if (err < 0) {
+			LOG_ERR("Failed to register PSK: %d", err);
+			return err;
+		}
 
-	err = tls_credential_add(PSK_TAG,
-				 TLS_CREDENTIAL_PSK_ID,
-				 psk_id,
-				 sizeof(psk_id) - 1);
-	if (err < 0) {
-		LOG_ERR("Failed to register PSK ID: %d", err);
-		return err;
+		static const char psk_id[] = "WallaBMC";
+		err = tls_credential_add(PSK_TAG,
+					 TLS_CREDENTIAL_PSK_ID,
+					 psk_id,
+					 sizeof(psk_id) - 1);
+		if (err < 0) {
+			LOG_ERR("Failed to register PSK ID: %d", err);
+			return err;
+		}
 	}
-#endif /* defined(CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED) */
-#endif /* defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS) */
+#endif
+
 	return err;
 }
 #else /* defined(CONFIG_APP_HTTPS) */


### PR DESCRIPTION
This tidies up a bunch of the crypto stuff. Selects a smaller set of modern ciphers, less shotgun config option selecting, better separates TLS1.3 and PSK options.

Fixes PSK but does not build it by default. Browers don't support it but it works if you use openssl tool with the PSK, so it might be useful for tiny BMCs that want to be managed securely with redfish clients that support PSK (redfishtool doesn't out of the box, but curl does).

This reduces Nucleo flash image size by about 55KB.

It also fixes the !HTTPS BMC web console by enabling SHA1 there at a cost of increasing hifive image size by about 4K.