### PR TITLE
ci: Enable build version based on tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           west init -l ../wallabmc
 
           # Update modules (fetches Zephyr kernel, HAL_STM32, etc.)
-          west update --narrow -o=--depth=1
+          west update --narrow -o=--depth=10000 -o=--tags
 
       - name: Build WallaBMC (sysbuild boards)
         if: ${{ matrix.board != 'qemu_cortex_m3' }}


### PR DESCRIPTION
ie.
`  |BMC|uart:~$ [00:00:00.040,000] <inf> wallabmc: Zephyr OS build: 06fd1cc311e7
`
becomes
`  |BMC|uart:~$ [00:00:00.040,000] <inf> wallabmc: Zephyr OS build: v4.3.0-6621-g4bb46742c7b6
`

Fingers crossed there is a tag within 10,0000 commits

This makes CI about 1 min slower. The west update goes from 2min to 3min and the overall CI runtime goes from 12min to 13min.

If you get all of git (ie no `--depth=10000`), it adds about 6min.