### PR TITLE
redfish: Add BMC UUID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ target_sources(app PRIVATE
 	src/net.c
 	src/power.c
 	src/synch.c
+	src/vpd.c
 )
 
 target_sources_ifdef(CONFIG_RTC app PRIVATE

--- a/Kconfig
+++ b/Kconfig
@@ -3,6 +3,12 @@
 
 mainmenu "WallaBMC"
 
+# This UUID should not be changed, it is a namespace from which
+# to generate other UUIDs for WallaBMC.
+config WALLABMC_UUID_NS
+	string
+	default "6ae4c3c7-fff0-472a-a77c-6f3f5a09ee7c"
+
 config APP_DNS_RESOLVE
 	bool
 	select REQUIRES_FULL_LIBC
@@ -153,12 +159,22 @@ config APP_HTTPS_PSK
 	depends on APP_HTTPS
 	select APP_CRYPTO_PSK
 
+config APP_BMC_UUID
+	bool "BMC UUID based on HWINFO device ID"
+	select MBEDTLS
+	select MBEDTLS_PSA_CRYPTO_C
+	select PSA_WANT_ALG_SHA_1
+	select UUID
+	select UUID_V5
+	select HWINFO
+
 config REDFISH
 	bool "Redfish server"
 	default y
 	select HTTP_SERVER
 	select HTTP_SERVER_CAPTURE_HEADERS
 	select JSON_LIBRARY
+	select APP_BMC_UUID
 	select BASE64
 
 if REDFISH

--- a/src/config.h
+++ b/src/config.h
@@ -4,6 +4,7 @@
  */
 #ifndef __CONFIG_H__
 #define __CONFIG_H__
+
 int config_init(void);
 int config_clear(void);
 const char *config_bmc_hostname(void);

--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,7 @@ LOG_MODULE_REGISTER(wallabmc, LOG_LEVEL_INF);
 #include "console_logger.h"
 #include "console_bridge.h"
 #include "console_bridge_ws.h"
+#include "vpd.h"
 
 static bool boot_finished = false;
 
@@ -203,6 +204,12 @@ int main(void)
 	LOG_DBG("RTC init");
 	if (rtc_init() < 0) {
 		LOG_ERR("RTC init failed");
+		return -1;
+	}
+
+	LOG_DBG("VPD init");
+	if (vpd_init() < 0) {
+		LOG_ERR("VPD init failed");
 		return -1;
 	}
 

--- a/src/redfish.c
+++ b/src/redfish.c
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "power.h"
 #include "rtc.h"
+#include "vpd.h"
 
 LOG_MODULE_REGISTER(redfish_app, CONFIG_LOG_DEFAULT_LEVEL);
 
@@ -743,11 +744,11 @@ static int manager_patch_handler(char *in_buf, size_t in_buf_len)
 /* GET /redfish/v1/Managers/bmc */
 static int manager_get_handler(char *out_buf, size_t out_buf_len)
 {
-	const struct redfish_manager manager = {
+	struct redfish_manager manager = {
 		.odata_id = "/redfish/v1/Managers/bmc",
 		.odata_type = "#Manager.v1_11_0.Manager",
 		.id = "bmc",
-		.uuid = "58893887-8974-2487-2389-389233423423",
+		.uuid = NULL,
 		.name = "WallaBMC",
 		.date_time = get_iso_time(),
 		.ethernet_interfaces = {
@@ -755,6 +756,11 @@ static int manager_get_handler(char *out_buf, size_t out_buf_len)
 		},
 	};
 	int ret;
+
+	ret = get_bmc_uuid_string(&manager.uuid);
+	if (ret < 0) {
+		LOG_ERR("Failed to get BMC UUID: %d", ret);
+	}
 
 	ret = json_obj_encode_buf(manager_descr, ARRAY_SIZE(manager_descr),
 				  &manager, out_buf, out_buf_len);

--- a/src/vpd.c
+++ b/src/vpd.c
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: © 2025-2026 Tenstorrent AI ULC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(wallabmc_vpd, LOG_LEVEL_INF);
+
+#include <zephyr/sys/uuid.h>
+#include <zephyr/drivers/hwinfo.h>
+
+#include "vpd.h"
+
+#ifdef CONFIG_APP_BMC_UUID
+static char bmc_uuid_str[UUID_STR_LEN];
+#else
+static const char *bmc_uuid_str = "58893887-8974-2487-2389-389233423423";
+#endif
+
+int get_bmc_uuid_string(const char **str)
+{
+	*str = bmc_uuid_str;
+	return 0;
+}
+
+int vpd_init(void)
+{
+#ifdef CONFIG_APP_BMC_UUID
+	struct uuid uuid_v5_ns;
+	struct uuid bmc_uuid;
+	uint8_t mcu_uid[16];
+	ssize_t length;
+	int ret;
+
+	ret = uuid_from_string(CONFIG_WALLABMC_UUID_NS, &uuid_v5_ns);
+	if (ret < 0) {
+		LOG_ERR("Could not parse namespace UUID %s", CONFIG_WALLABMC_UUID_NS);
+		return -EINVAL;
+	}
+
+	length = hwinfo_get_device_id(mcu_uid, sizeof(mcu_uid));
+	if (length < 0) {
+		LOG_ERR("Could not get device UID");
+		return -ENODEV;
+	}
+
+	ret = uuid_generate_v5(&uuid_v5_ns, mcu_uid, length, &bmc_uuid);
+	if (ret < 0) {
+		LOG_ERR("Could not generate device UUID");
+		return -EINVAL;
+	}
+
+	ret = uuid_to_string(&bmc_uuid, bmc_uuid_str);
+	if (ret < 0) {
+		LOG_ERR("Could not convert UUID to string");
+		return -EINVAL;
+	}
+#endif
+	return 0;
+}

--- a/src/vpd.h
+++ b/src/vpd.h
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: © 2025-2026 Tenstorrent AI ULC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef __VPD_H__
+#define __VPD_H__
+
+int get_bmc_uuid_string(const char **str);
+int vpd_init(void);
+
+#endif


### PR DESCRIPTION
Use the STM32 device UID to generate a UUID for the BMC. The WallaBMC "namespace UUID" was generated with uuidgen, and can be used to generate UUIDs from other unique numbers.