### PR TITLE
ci: Use an older zephyr docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     # ubuntu-latest does not have enough space, use a large TT runner
     runs-on: tt-ubuntu-2404-large-stable
     container:
-      image: zephyrprojectrtos/ci:latest
+      image: zephyrprojectrtos/ci:v0.28.9
 
     strategy:
       matrix:


### PR DESCRIPTION
latest moved to the 1.0-rc toolchain, which has broken building. Move to a release tag for now.