### PR TITLE
docs: add P550 BMC hardware reference

### DIFF
--- a/boards/sifive/hifive_premier_p550_mcu/P550_BMC_HARDWARE.md
+++ b/boards/sifive/hifive_premier_p550_mcu/P550_BMC_HARDWARE.md
@@ -1,0 +1,786 @@
+# HiFive Premier P550 BMC Hardware Reference
+
+This document maps the STM32F407VET6 MCU pins to board signals on the SiFive
+HiFive Premier P550 carrier board (HF106C), based on the carrier board
+schematic v3.1 (page 20 "MCU MISC" and "MCU IO FUNCTION USED LIST"), and
+verified by reverse engineering the original ESWIN BMC firmware ELF
+(`STM32F407VET6_BMC.elf` from the MCU tools repo). It serves as a reference
+for implementing missing BMC features in WallaBMC.
+
+**Carrier board schematic**: https://www.sifive.com/document-file/premier-p550-carrier-board-schematic (v3.1)
+**SOM schematic**: https://sifive.cdn.prismic.io/sifive/ZwMDL7VsGrYSwa3P_HiFivePremierP550SOMSchematicv3.0.pdf
+**Getting started / user guide**: https://sifive.cdn.prismic.io/sifive/Z1h2p5bqstJ98RbK_HF106_user_guide_V1p2_en.pdf
+**MCU user manual**: https://www.sifive.com/document-file/premier-p550-mcu-user-manual
+**MCU tools repo**: https://github.com/sifiveinc/hifive-premier-p550-tools
+
+## MCU overview
+
+- **MCU**: STM32F407VET6 (schematic designator U51A/U51B, page 20 "MCU MISC")
+- ARM Cortex-M4, 168 MHz, 512 KB flash, 192+4 KB SRAM
+- Powered from ATX 5V standby rails (always-on when ATX PSU has standby power)
+- MCU I/O voltage: 1.8V (VDD18_MCU from SY8113B buck off 5VSB)
+- RTC backup: 3.3V coin cell battery (J27) OR VDD33_VSB via BAT54CW diode
+
+## Complete STM32 pin map
+
+Source: "MCU IO FUNCTION USED LIST" table from carrier board schematic v3.1,
+page 20.
+
+### Currently implemented in WallaBMC
+
+| STM32 Pin | Signal | DTS node / alias | Description |
+|-----------|--------|------------------|-------------|
+| PD4 | DCDC POWER ON (DC_EN) | `dcen` / `power-gpio-1` | DC-DC converter enable (main power rails). Active HIGH. |
+| PE3 | ATX POWER ON REQUEST | `atxpson` / `power-gpio-2` | ATX PSU power-on signal. Active HIGH. |
+| PE13 | LED_PWM3 (Blue) | `blue_led` / `status-led` | RGB LED blue channel, Morse "OK" blinker |
+| PE11 | LED_PWM2 (Green) | `green_led` | RGB LED green channel (defined, unused by code) |
+| PE9 | LED_PWM1 (Red) | `red_led` | RGB LED red channel (defined, unused by code) |
+| PB1 | RECOVERY KEY (K_REC) | `user_button_recovery` / `sw0` | Recovery button. Active LOW. **Bug**: `reset-button` alias missing in overlay, so `button_init()` silently skips. |
+| PB15 | UART MUX SEL | `uartmuxsel` | TS5A23157 mux control. Active HIGH. (see UART mux section) |
+| PD8/PD9 | USART3 TX/RX | `usart3` | MCU debug console (via FT4232H ch D -> USB debug) |
+| PC6/PC7 | USART6 TX/RX | `usart6` | Console bridge to SoC UART0 (DMA-enabled) |
+| PC10/PC11 | UART4 TX/RX | `uart4` | Connected to SoC UART2 (enabled in DTS, unused by code) |
+| PE0 | JTAG TCK | `jtagtck` | SoC JTAG bit-bang clock (TCP port 7777) |
+| PE1 | JTAG TMS | `jtagtms` | SoC JTAG bit-bang mode select |
+| PE2 | JTAG TDO | `jtagtdo` | SoC JTAG bit-bang data out (input, pull-up) |
+| PE4 | JTAG TDI | `jtagtdi` | SoC JTAG bit-bang data in |
+| PB2 | BOOT1 | `boot1` | STM32 BOOT1 pin (defined but unused) |
+| PA1,PA2,PA7 | RMII + MDIO | `mac`, `mdio` | LAN8720A PHY at addr 0, 100 Mbit BMC Ethernet |
+| PB11-PB13 | ETH TX | (part of mac) | Ethernet TX enable, TXD0, TXD1 |
+| PC1,PC4,PC5 | ETH RX + MDC | (part of mac/mdio) | Ethernet RXD0, RXD1, MDC |
+| PC0 | EPHY RESETN | (part of mac) | Ethernet PHY reset. Active LOW. |
+
+### NOT yet implemented (features to add)
+
+#### SOM reset control (PD5 output, PD6 input)
+
+| STM32 Pin | Signal (from schematic) | Direction | Active | Description |
+|-----------|------------------------|-----------|--------|-------------|
+| **PD5** | SOM WARM RESET | Output | LOW | Drives SOM warm reset. Active-low: assert (drive low) to reset, deassert (drive high or float) to release. |
+| **PD6** | SOM RESET OUT DETECT | Input | LOW | SOM reset status feedback. Goes low when SOM is in reset. Can be used to confirm reset completed or detect SoC-initiated resets. |
+
+**Implementation**: Add `reset-gpio` alias in the overlay pointing to a new
+GPIO node for PD5 (active-low). The existing `power_reset()` in `power.c`
+already supports this alias and will pulse it for 1 second. PD6 could
+optionally be used to confirm reset state or detect SoC-initiated resets.
+
+```dts
+/* In the DTS gpio_keys node: */
+som_reset: som_reset {
+    gpios = <&gpiod 5 GPIO_ACTIVE_LOW>;
+    label = "SOM_RESET";
+};
+som_rst_detect: som_rst_detect {
+    gpios = <&gpiod 6 GPIO_ACTIVE_LOW>;
+    label = "SOM_RST_DETECT";
+};
+
+/* In the overlay aliases: */
+reset-gpio = &som_reset;
+```
+
+#### Power-good monitoring (PE5)
+
+| STM32 Pin | Signal (from schematic) | Direction | Active | Description |
+|-----------|------------------------|-----------|--------|-------------|
+| **PE5** | BUCK POWER GOOD DETECTION | Input | HIGH | Combined power-good from VDD_5V_SOM_PG and VDD_5V_SYS_PG buck converters. HIGH = power rails stable. |
+
+**Implementation**: Add a GPIO input node. Use it to:
+1. Confirm power-on completed successfully after asserting DC_EN + ATX_PS_ON
+2. Detect unexpected power loss (interrupt on falling edge)
+3. Report true hardware power status via Redfish and shell (instead of just
+   tracking the software-requested state)
+
+```dts
+pwrok: pwrok {
+    gpios = <&gpioe 5 GPIO_ACTIVE_HIGH>;
+    label = "DCDC_PWR_OK";
+};
+```
+
+#### Power button input (PA12)
+
+| STM32 Pin | Signal (from schematic) | Direction | Active | Description |
+|-----------|------------------------|-----------|--------|-------------|
+| **PA12** | POWER ON KEY | Input | LOW | Front-panel power button press detection. Active-low. |
+
+**Implementation**: This is distinct from the recovery button (PB1). It allows
+the BMC to detect a physical power button press and trigger power on/off of the
+host. Add as a gpio-key with interrupt support and connect to the power
+on/off logic. Consider toggle behavior (press = power on if off, power off if
+on) and configurable long-press for force-off.
+
+```dts
+power_button: power_button {
+    gpios = <&gpioa 12 GPIO_ACTIVE_LOW>;
+    label = "POWER_BUTTON";
+};
+```
+
+#### SOM boot mode selection (PD0, PD1, PD2, PD3)
+
+| STM32 Pin | Signal (from schematic) | Direction | Description |
+|-----------|------------------------|-----------|-------------|
+| **PD0** | SOM BOOT MODE CTRL 0 (BOOT_SEL0) | In/Out | SoC boot source bit 0 |
+| **PD1** | SOM BOOT MODE CTRL 1 (BOOT_SEL1) | In/Out | SoC boot source bit 1 |
+| **PD2** | SOM BOOT MODE CTRL 2 (BOOT_SEL2) | In/Out | SoC boot source bit 2 |
+| **PD3** | SOM BOOT MODE CTRL 3 (BOOT_SEL3) | In/Out | SoC boot source bit 3 |
+
+These control the EIC7700X SoC boot source. The schematic labels them as
+INOUT with "USER DEFINE" active level, meaning they share control with the
+on-board DIP switch (SW1). The MCU must set its pins to high-impedance
+(input mode) if the DIP switch is being used manually.
+
+**Boot modes** (from EIC7700X documentation):
+
+When OTP security bit = 1 (only lower 2 bits matter):
+
+| SEL[3:0] | Boot CPU | First Boot | Second Boot |
+|----------|----------|------------|-------------|
+| xx00 | SCPU | ROM | UART |
+| xx01 | SCPU | ROM | eMMC |
+| xx10 | SCPU | ROM | SPI NOR |
+| xx11 | SCPU | ROM | USB |
+
+When OTP security bit = 0 (all 4 bits used):
+
+| SEL[3:0] | Boot CPU | First Boot | Second Boot |
+|----------|----------|------------|-------------|
+| 0000 | SCPU | ROM | UART |
+| 0001 | SCPU | ROM | eMMC |
+| 0010 | SCPU | ROM | SPI NOR |
+| 0011 | SCPU | ROM | USB |
+| 0100 | SCPU | SPI NOR | UART |
+| 0101 | SCPU | SPI NOR | eMMC |
+| 0110 | SCPU | SPI NOR | SPI NOR |
+| 0111 | SCPU | SPI NOR | USB |
+| 1x00 | U84 | SPI NOR | UART |
+| 1x01 | U84 | SPI NOR | eMMC |
+| 1x10 | U84 | SPI NOR | SPI NOR |
+| 1x11 | U84 | SPI NOR | USB |
+
+**Implementation**: Add GPIO output nodes for each pin. Implement a `boot`
+shell command that allows selecting the SoC boot source before power-on or
+reset. Store the selected boot mode in persistent config. Default to
+high-impedance (follow DIP switch) unless explicitly overridden.
+
+#### Fan control (PD12, PD13 PWM outputs; PE6, PB14 tachometer inputs)
+
+| STM32 Pin | Signal (from schematic) | Direction | Description |
+|-----------|------------------------|-----------|-------------|
+| **PD12** | MCU TIMER4 PWM1 (TIM4_CH1) | Output | CPU/SOM fan PWM speed control |
+| **PD13** | MCU TIMER4 PWM2 (TIM4_CH2) | Output | Chassis fan PWM speed control |
+| **PE6** | CHASS FAN TACH1 | Input | Chassis fan 1 tachometer (RPM sensing) |
+| **PB14** | CHASS FAN TACH2 | Input | Chassis fan 2 tachometer (RPM sensing) |
+
+Note: The schematic also shows TIM4_CH3 (PD14) and TIM4_CH4 (PD15) on the
+STM32 pinout, but only CH1 and CH2 are listed in the MCU IO function table.
+
+Both PWM outputs use Timer 4 (TIM4). The tachometer inputs typically provide
+two pulses per revolution for standard PC fans.
+
+**Implementation**: Use Zephyr's PWM driver for TIM4 channels 1 and 2. Use
+GPIO interrupt (rising edge) or timer input capture for tachometer inputs.
+Expose fan speed via Redfish `Thermal` resource and a `fan` shell command.
+
+```dts
+&timers4 {
+    status = "okay";
+    pwm4: pwm {
+        status = "okay";
+        pinctrl-0 = <&tim4_ch1_pd12 &tim4_ch2_pd13>;
+        pinctrl-names = "default";
+    };
+};
+```
+
+#### I2C buses (I2C1: PB6/PB7, I2C3: PA8/PC9)
+
+**I2C3** (PA8 SCL, PC9 SDA, PA9 SMBA) - carrier board peripherals:
+
+| Device | Address | I/O Voltage | Description |
+|--------|---------|-------------|-------------|
+| INA226 power monitor | 0x44 (1000100) | 3.3V | 12V input rail power monitor. Measures voltage and current. SMBus alert on PA9 (MCU_I2C3_SMBA) for over-current/over-voltage notification. |
+
+**I2C1** (PB6 SCL, PB7 SDA) - shared bus:
+
+| Device | Address | I/O Voltage | Description |
+|--------|---------|-------------|-------------|
+| AT24C02C EEPROM | 0x50 (1010000) | 1.8V | 2 Kbit EEPROM. Stores carrier board information (serial number, MAC, manufacturing data). Write-protect controlled by PC8 (EEPROM_WP, active LOW per schematic). |
+
+The schematic notes (page 3 ADDRESS MAP):
+> "SOM, FT4232 and BMC MCU share I2C BUS"
+
+This means I2C1 is shared between the MCU, the SoC (I2C10), and the FT4232H
+(via BCBUS4/BCBUS5). Bus arbitration is controlled by a TMUX1574 mux (U77).
+
+**Related control GPIOs**:
+
+| STM32 Pin | Signal (from schematic) | Direction | Active | Description |
+|-----------|------------------------|-----------|--------|-------------|
+| **PA3** | I2C_MUX_EN | Output | - | Enable TMUX1574 mux (U77) for I2C bus routing. Controls whether SoC or MCU owns the shared I2C1 bus. |
+| **PC8** | EEPROM WRITE PROTECT | Output | HIGH | EEPROM write-protect control. HIGH = protected, LOW = writable. (Confirmed: original firmware `eepromwp-s 0` writes PC8=LOW="disabled", `eepromwp-s 1` writes PC8=HIGH="enabled".) |
+
+**Implementation**: Enable I2C1 and I2C3 in device tree. Implement:
+1. INA226 driver for 12V rail monitoring (voltage, current, power). Zephyr has
+   an upstream `ti,ina226` sensor driver. Expose via Redfish `Power` resource.
+2. EEPROM read/write for board identity data (serial number, MAC, etc.)
+3. I2C mux control (PA3) to arbitrate bus access with SoC. Set mux to MCU
+   before I2C1 operations, release after.
+
+```dts
+&i2c1 {
+    pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
+    pinctrl-names = "default";
+    status = "okay";
+    clock-frequency = <I2C_BITRATE_STANDARD>;
+
+    eeprom: eeprom@50 {
+        compatible = "atmel,at24";
+        reg = <0x50>;
+        size = <256>;
+    };
+};
+
+&i2c3 {
+    pinctrl-0 = <&i2c3_scl_pa8 &i2c3_sda_pc9>;
+    pinctrl-names = "default";
+    status = "okay";
+    clock-frequency = <I2C_BITRATE_STANDARD>;
+
+    ina226: ina226@44 {
+        compatible = "ti,ina226";
+        reg = <0x44>;
+        rshunt-micro-ohms = <1000>; /* 1 mOhm shunt resistor */
+    };
+};
+```
+
+#### SPI to SoC (SPI2: PB9, PB10, PC2, PC3)
+
+| STM32 Pin | Signal (from schematic) | Direction | Description |
+|-----------|------------------------|-----------|-------------|
+| **PB9** | MCU SPI2 NSS | Output | SPI2 chip select to SOM |
+| **PB10** | MCU SPI2 SCK | Output | SPI2 clock |
+| **PC2** | MCU SPI2 MISO | Input | SPI2 MISO from SOM |
+| **PC3** | MCU SPI2 MOSI | Output | SPI2 MOSI to SOM |
+
+Direct SPI bus between MCU and SoC through the SOM edge connector. PB9
+(SPI2_CS) is single-purpose — connected straight to the SOM connector and
+fed into the main EIC7700X SoC. Could be used for high-bandwidth MCU-to-SoC
+communication (e.g., firmware updates, IPMI/MCTP transport). Lower priority
+— requires SoC-side driver support.
+
+#### SPI1 / onboard flash (PA4, PA5, PA6, PB5) - optional
+
+| STM32 Pin | Signal (from schematic) | Direction | Description |
+|-----------|------------------------|-----------|-------------|
+| **PA4** | MCU SPI1 NSS | Output | SPI1 chip select (to W25Q32 flash, U52) |
+| **PA5** | MCU SPI1 SCK | Output | SPI1 clock |
+| **PA6** | MCU SPI1 MISO | Input | SPI1 MISO |
+| **PB5** | MCU SPI1 MOSI | Output | SPI1 MOSI |
+
+The W25Q32 (32 Mbit / 4 MB SPI flash) footprint exists on the carrier board
+but is **not mounted** by default. If populated, could provide additional
+storage for BMC firmware, logs, or configuration beyond the 512 KB internal
+flash.
+
+#### Front panel LEDs (PD10, PD11)
+
+| STM32 Pin | Signal (from schematic) | Direction | Active | Description |
+|-----------|------------------------|-----------|--------|-------------|
+| **PD10** | POWER LED | Output | HIGH | Front-panel power LED indicator |
+| **PD11** | SLEEP LED | Output | HIGH | Front-panel sleep/standby LED indicator |
+
+**Implementation**: Add as LED nodes in DTS. Drive PWR_LED on when host power
+is on (track power_get_state()), SLP_LED when host is powered off but BMC is
+running (standby indicator).
+
+```dts
+/* Add to the leds node in DTS: */
+pwr_led: pwr_led {
+    gpios = <&gpiod 10 GPIO_ACTIVE_HIGH>;
+    label = "Power LED";
+};
+slp_led: slp_led {
+    gpios = <&gpiod 11 GPIO_ACTIVE_HIGH>;
+    label = "Sleep LED";
+};
+```
+
+#### Other/misc GPIO (PE15)
+
+| STM32 Pin | Signal (from schematic) | Direction | Description |
+|-----------|------------------------|-----------|-------------|
+| **PE15** | DC_POWER_EN1 | Output | Duplicates the DC_EN signal (same as PD4) through a not-mounted 0-ohm resistor. On DVB-2 boards this is a second DC enable output. In practice the 0R is NM so this pin has no effect and does not need to be driven. |
+
+## FT4232H channel mapping and debug USB
+
+The FTDI FT4232HL (U46) connects via USB-C debug port (J23) and provides 4
+independent channels, each appearing as a separate USB serial/JTAG interface:
+
+| Channel | STM32 Pins | Function | Notes |
+|---------|-----------|----------|-------|
+| **A** (ADBUS) | - (to SoC) | SoC JTAG | SoC JTAG via TMUX1574 mux (U70). Jumper J53 selects between FT4232H or MIPI-20 connector (J22/J59). |
+| **B** (BDBUS) | PA13, PA14, PA15, PB3 | MCU JTAG/SWD | Direct connection to STM32 JTAG/SWD. Used by OpenOCD for BMC flashing. Level-shifted via TXB0108 (U45) between 3.3V and 1.8V. |
+| **C** (CDBUS) | via mux to PC6/PC7 | UART (muxed) | Goes through TS5A23157 mux (U64). UART_MUX_SEL selects MCU USART6 or SoC UART0. |
+| **D** (DDBUS) | PD8/PD9 | MCU console UART | Direct connection to STM32 USART3. This is the Zephyr shell. |
+
+The FT4232H also provides I2C via BCBUS4/BCBUS5, connected through a PCA9306
+level shifter (U49) to the shared EEPROM I2C bus (I2C1).
+
+## UART mux architecture
+
+**Channel C UART mux (U64, TS5A23157)**:
+- `UART_MUX_SEL = 0` (PB15 LOW, default): FT4232 ch C talks directly to SoC UART0
+- `UART_MUX_SEL = 1` (PB15 HIGH): FT4232 ch C talks to MCU USART6
+
+When a network client connects to the console bridge (TCP port 22), WallaBMC
+sets UART_MUX_SEL=1 so that:
+- TCP client <-> MCU USART6 <-> (via mux) <-> SoC UART0
+
+When no TCP client is connected (MUX_SEL=0):
+- USB debug ch C <-> (direct) <-> SoC UART0
+
+This means the USB debug UART channel C is disconnected from the SoC during
+a console bridge TCP session. This is by design - it prevents contention
+between USB and network console users.
+
+## Power architecture and sequencing
+
+The MCU controls the board's power-on sequence:
+
+1. MCU is always powered from ATX 5V standby (VDD_5VSB -> VDD18_MCU via SY8113B buck)
+2. On `power on`:
+   - Assert **DC_EN** (PD4 HIGH) -> enables main DC-DC converters
+     (SQ20056RAC for 5V/3.3V carrier, SY81012VDC for 5V SOM/SYS)
+   - Assert **ATX_PS_ON** (PE3 HIGH) -> tells ATX PSU to turn on main 12V
+3. Monitor **DCDC_PWR_OK** (PE5) -> goes HIGH when power rails are stable
+4. On `power off`: deassert both DC_EN and ATX_PS_ON
+5. **Auto power-on jumper** J61 (2-pin) can force power-on at ATX standby
+
+**Original firmware power-on sequence** (from `hf_power_task` reverse engineering):
+1. Assert **ATX_PS_ON** (PE3 HIGH) first
+2. Assert **DC_EN** (PD4 HIGH)
+3. Poll **DCDC_PWR_OK** (PE5) up to 10 times with 200ms delays (2 second timeout)
+4. If DC good: init I2C3, check carrier board EEPROM info, release SOM reset (PD5 HIGH)
+5. Set MCU LED to green, chassis power LED on / sleep LED off
+6. If DC good timeout: abort power-on, go back to off state
+
+**Original firmware power-off sequence** (from `set_power_off`):
+1. Assert SOM reset (PD5 LOW via `som_reset_control(1)`)
+2. Delay 10ms
+3. DC power off (PD4 LOW)
+4. Delay 10ms
+5. ATX power off (PE3 LOW)
+6. Delay 10ms
+7. Set MCU LED to red, power LED off / sleep LED on
+
+**Original firmware SOM reset behavior** (from `som_reset_control`):
+- Assert reset: PD5=LOW, reconfigure as output, deinit UART4+USART6, PB9=LOW
+- Release reset: PD5=HIGH, reconfigure as IT_FALLING (interrupt input to detect
+  SoC-initiated resets), reinit UART4+USART6, PB9=HIGH, LED=green, chassis LED=power on
+
+**Current WallaBMC implementation gaps**:
+- Does not monitor DCDC_PWR_OK (PE5) to confirm power-on success
+- Does not sequence ATX_PS_ON before DC_EN (both asserted simultaneously)
+- Does not hold SOM in reset during power-on, nor release it after DC good
+- Does not drive front panel LEDs (PD10/PD11) to reflect power state
+- Does not detect power button presses (PA12)
+- Does not detect SoC-initiated resets via PD6 interrupt
+- Does not deinit/reinit UARTs during SOM reset
+- `power_get_state()` returns software-requested state, not actual hardware state
+
+## Known bugs in current DTS/overlay
+
+1. **Missing `reset-button` alias**: The P550 overlay does not define
+   `reset-button = &user_button_recovery`. The DTS defines the
+   `user_button_recovery` node and the `sw0` alias, but `button.c` looks for
+   `DT_ALIAS(reset_button)`. This means the recovery button **does nothing**
+   on P550. Fix: add `reset-button = &user_button_recovery;` to the overlay
+   aliases section.
+
+2. **JTAG node `compatible`**: Both P550 and nucleo overlays use
+   `compatible = "gpio-leds"` for the JTAG node with a comment "What is a
+   better setting for this?". This works because `gpio-leds` provides the
+   `gpios` property, but is semantically incorrect. A custom compatible like
+   `"gpio-jtag"` or just removing the compatible and using raw GPIO nodes
+   would be cleaner.
+
+3. **JTAG pins "not connected for now"**: Comment in overlay suggests the SoC
+   JTAG bit-bang pins (PE0-PE4) are not physically wired. The schematic does
+   show these STM32 pins routed out, but the SoC JTAG chain also goes through
+   a separate TMUX1574 mux (U70) to the FT4232H channel A. It is unclear
+   whether the MCU bit-bang path connects to the same JTAG chain or is a
+   separate debug interface. Hardware verification needed.
+
+## Feature implementation priority
+
+Recommended order based on impact and complexity:
+
+1. **Fix reset-button alias** - one-line DTS fix, enables config-clear button
+2. **SOM reset** (PD5) - add DTS node + alias, existing `power_reset()` handles it
+3. **Power-good monitoring** (PE5) - add GPIO input, confirm power state
+4. **Front panel LEDs** (PD10/PD11) - simple GPIO output, track power state
+5. **Power button** (PA12) - GPIO interrupt, triggers power on/off
+6. **I2C3 + INA226** - 12V rail power monitoring, Redfish Power resource
+7. **Fan control** (TIM4 PWM + tachometers) - requires PWM driver, new module
+8. **Boot mode select** (PD0-PD3) - new shell command, persistent config
+9. **I2C1 + EEPROM** - board identity, MAC address storage
+10. **SPI2 to SoC** - MCU-SoC communication channel (lower priority)
+
+## Carrier board EEPROM (AT24C02C on I2C1)
+
+The AT24C02C EEPROM at I2C1 address 0x50 stores carrier board identity and MAC
+addresses. The original firmware stores two copies for redundancy.
+
+### EEPROM layout
+
+| Offset | Size | Description |
+|--------|------|-------------|
+| 0x00-0x32 | 51 | Primary board info record |
+| 0x50-0x82 | 51 | Backup board info record (identical format) |
+
+### Board info record structure (51 bytes)
+
+| Offset | Size | Type | Field | CLI name | Factory default |
+|--------|------|------|-------|----------|-----------------|
+| 0 | 4 | uint32_t LE | magicNumber | `magic` | 0x45505EF1 |
+| 4 | 1 | uint8_t | formatVersionNumber | `format` | 0x03 |
+| 5 | 2 | uint16_t LE | productIdentifier | `productid` | 0x0004 |
+| 7 | 1 | uint8_t | pcbRevision | `pcbr` | 0x10 |
+| 8 | 1 | uint8_t | bomRevision | `bomr` | 0x10 |
+| 9 | 1 | uint8_t | bomVariant | `bomv` | 0x10 |
+| 10 | 18 | char[18] | boardSerialNumber | `boardsn` | (manufacturing) |
+| 28 | 1 | uint8_t | manufacturingTestStatus | `manu` | 0x00 |
+| 29 | 6 | uint8_t[6] | MAC0 (SoC ETH0) | `setmac 0` | (manufacturing) |
+| 35 | 6 | uint8_t[6] | MAC1 (SoC ETH1) | `setmac 1` | (manufacturing) |
+| 41 | 6 | uint8_t[6] | MCU MAC (BMC ETH) | `setmac 2` | (manufacturing) |
+| 47 | 4 | uint32_t LE | CRC32 checksum | - | (computed) |
+
+CRC32 is standard CRC-32 (same polynomial as Ethernet/zlib) computed over
+bytes 0-46, then bitwise inverted (`~crc`). The original firmware function
+`hf_crc32()` initializes CRC to 0, runs a table-based CRC, then inverts.
+
+### EEPROM access requirements
+
+1. **I2C mux**: Assert PA3 (I2C_MUX_EN) to route I2C1 bus to MCU before
+   any EEPROM access. The bus is shared with SoC (I2C10) and FT4232H.
+2. **Write protect**: PC8 must be driven LOW to allow writes. The original
+   firmware initializes PC8=HIGH (protected) at boot and only lowers it
+   during explicit write operations.
+3. **Mutex**: The original firmware uses a FreeRTOS mutex (`gEEPROM_Mutex`
+   at 0x20000584) to serialize access.
+4. **Dual copy**: On boot, `es_check_carrier_board_info` reads primary
+   (offset 0x00), validates CRC32. If corrupt, falls back to backup
+   (offset 0x50). If both corrupt, restores factory defaults.
+
+### Original firmware `cbinfo-g` output format
+
+```
+[Carrierboard Information:]
+magicNumber:0x45505ef1
+formatVersionNumber:0x3
+productIdentifier:0x4
+pcbRevision:0x10
+bomRevision:0x10
+bomVariant:0x10
+SN:HF106C-XXXXX
+manufacturingTestStatus:0x0
+```
+
+### Original firmware `setmac` command
+
+```
+setmac <index,0-2> <mac,like a1:26:39:91:b0:22>
+```
+
+- Index 0: SoC ETH0 MAC (at EEPROM offset 29)
+- Index 1: SoC ETH1 MAC (at EEPROM offset 35)
+- Index 2: BMC MCU MAC (at EEPROM offset 41)
+
+After setting, both primary and backup EEPROM records are updated with new CRC.
+The original firmware prints: `The MAC setting will be valid after rebooting the carrier board!!!`
+
+### WallaBMC implementation notes
+
+A `boardinfo` shell command should:
+1. Enable I2C1 in device tree (PB6 SCL, PB7 SDA)
+2. Configure PA3 as output for I2C mux control
+3. Configure PC8 as output for EEPROM write protect
+4. Read 51 bytes from EEPROM at I2C addr 0x50, offset 0x00
+5. Validate CRC32; fallback to offset 0x50 if primary corrupt
+6. Parse and display fields per the struct above
+7. The MCU MAC could optionally be used to set the BMC Ethernet MAC
+   address at boot instead of using the compiled-in default
+
+## MCU-SoC UART4 protocol
+
+The MCU and SoC communicate over UART4 (PC10 TX, PC11 RX, 115200 8N1) using
+a fixed-length binary protocol. This is used to query SoC status, get SoM
+board info, read temperatures, and exchange keepalive messages.
+
+### Packet format (267 bytes, 0x10B)
+
+| Offset | Size | Field | Description |
+|--------|------|-------|-------------|
+| 0-3 | 4 | magic | `55 AA 5A A5` |
+| 4-7 | 4 | reserved | Zero |
+| 8 | 1 | type | Packet type: `0x01` = request |
+| 9 | 1 | source | Source ID: `0x03` = CLI, `0x05` = web API |
+| 10 | 1 | reserved | Zero |
+| 11 | 1 | cmd | Command ID (see command table below) |
+| 12-261 | 250 | payload | Request/response payload, zero-padded |
+| 262 | 1 | checksum | XOR of bytes [8, 9, 11] XOR payload[0..N-1] |
+| 263-266 | 4 | tail | `BA BD BA BD` |
+
+Both request and response use the same 267-byte frame format. The SoC runs a
+matching daemon that receives on its UART0 and responds in the same format.
+
+### Checksum calculation
+
+```c
+uint8_t checksum = packet[8] ^ packet[9] ^ packet[11];
+for (int i = 0; i < payload_len; i++)
+    checksum ^= packet[12 + i];
+packet[262] = checksum;
+```
+
+Where `payload_len` is taken from `packet[11]` (the command byte also encodes
+the response data size in the original firmware).
+
+### Command table
+
+| Cmd ID | Name | Direction | Payload size | Description |
+|--------|------|-----------|-------------|-------------|
+| 0x00 | Keepalive | MCU->SoC->MCU | 0 | SoC daemon liveness check. Sent periodically (every 6 seconds via `SomRestartTimer`). If no response after 5 seconds, SoC is considered down. |
+| 0x0C | PVT/Temperature | MCU->SoC->MCU | 12 | Get CPU temp, NPU temp, and fan speed from SoC |
+| 0x21 | SoM Board Info | MCU->SoC->MCU | 33 | Get SoM board identity (same struct as EEPROM) |
+
+### Response handling
+
+The response arrives asynchronously via UART4 RX interrupt
+(`HAL_UARTEx_RxEventCallback`). The `uart4_protocol_task` matches responses to
+pending requests using a linked list and notifies the waiting task via
+FreeRTOS task notifications. Timeout is configurable per command (typically
+1000ms).
+
+Response status is at offset 0x130 in the response context:
+- `0x00` = success, response data follows at offset 0x131
+- `0xFF` = no response / timeout
+- Other values = error codes
+
+### `sominfo` command (cmd 0x21)
+
+Sends cmd 0x21 to SoC, receives 33 bytes of board info in the same format
+as the EEPROM carrier board record (but from the SoM's own storage):
+
+```
+[Somboard Information:]
+magicNumber:0x...
+version:0x...
+id:0x...
+pcb:0x...
+bom_revision:0x...
+bom_variant:0x...
+SN:...
+status:0x...
+```
+
+The struct matches the first 33 bytes of the carrier board record (magic
+through manufacturingTestStatus), without the MAC addresses or CRC.
+
+**Requires**: SoC must be powered on and running the UART protocol daemon.
+If SoC is off, `web_cmd_handle` returns error code 1 immediately.
+
+### Temperature/PVT command (cmd 0x0C)
+
+Sends cmd 0x0C to SoC, receives 12 bytes:
+
+| Offset | Size | Type | Field |
+|--------|------|------|-------|
+| 0 | 4 | int32_t | cpu_temp (millidegrees Celsius) |
+| 4 | 4 | int32_t | npu_temp (millidegrees Celsius) |
+| 8 | 4 | int32_t | fan_speed (RPM) |
+
+Original firmware display format:
+```
+cpu_temp(Celsius):XX.X  npu_temp(Celsius):XX.X  fan_speed(rpm):XXXX
+```
+
+Conversion: `degrees = raw / 1000`, `fraction = raw % 1000`.
+
+### SoC keepalive mechanism
+
+The original firmware runs a keepalive timer (`SomRestartTimer`, 6 second
+interval). It sends cmd 0x00 to the SoC. If no response is received within
+5 seconds (`SOM_STATUS_CHECK_STATE` timer), the SoC is considered
+unresponsive. The keepalive state is exposed via `somwork` CLI command
+(`Som Work Status: ...`).
+
+### WallaBMC implementation notes
+
+To implement SoC communication:
+1. UART4 is already enabled in the DTS (PC10/PC11, 115200 baud) but unused
+   by WallaBMC code
+2. Implement the 267-byte packet framing with magic/checksum/tail
+3. Add async TX/RX with timeout (similar to console_bridge pattern)
+4. Register shell commands: `sominfo`, `temp` (or integrate into Redfish)
+5. Optionally implement keepalive for SoC liveness monitoring
+6. The SoC-side daemon must be running (part of the SoC's Linux userspace)
+
+## Original firmware CLI command reference
+
+Complete list of CLI commands from the original ESWIN firmware, extracted from
+string table and symbol analysis:
+
+### Power management
+
+| Command | Description |
+|---------|-------------|
+| `sompower-g` | Get SOM power status ("ON" or "OFF") |
+| `sompower-s` | Set SOM power on/off |
+| `powerlost-g` | Get power-lost resume attribute ("enabled"/"disabled"). When enabled, SoC auto-powers-on after ATX power restore. |
+| `powerlost-s` | Set power-lost resume (enable/disable auto restart after power loss) |
+
+### SoC console routing
+
+| Command | Description |
+|---------|-------------|
+| `somconsole-g` | Get SoC console routing ("UART" or "Telnet") |
+| `somconsole-s` | Set SoC console routing: `0` = via UART (FT4232H ch C), `1` = via Telnet (MCU bridges network to USART6). Controls UART_MUX_SEL (PB15). |
+
+### Boot configuration
+
+| Command | Description |
+|---------|-------------|
+| `bootsel-g` | Get software boot select configuration (shows current BOOT_SEL[3:0] and whether HW or SW controlled) |
+| `bootsel-s` | Set software boot select. When SW-controlled, MCU drives PD0-PD3 as outputs. When HW-controlled, MCU sets PD0-PD3 as inputs (follows DIP switch SW1). |
+
+### Board identity (carrier board EEPROM)
+
+| Command | Description |
+|---------|-------------|
+| `cbinfo-g` | Display carrier board information from EEPROM (magic, format, product ID, PCB/BOM revision, serial number, test status) |
+| `cbinfo-s` | Set carrier board EEPROM fields: `cbinfo-s <field> <hex_value>`. Fields: magic, format, productid, pcbr, bomr, bomv, boardsn, manu |
+| `eepromwp-s` | Set EEPROM write protect: `0` = disabled (writable), `1` = enabled (protected). Controls PC8. |
+| `setmac` | Set MAC address: `setmac <0-2> <aa:bb:cc:dd:ee:ff>`. Index 0=SoC ETH0, 1=SoC ETH1, 2=BMC MCU. |
+
+### SoC status (requires SoC powered on)
+
+| Command | Description |
+|---------|-------------|
+| `sominfo` | Display SoM board information (magic, version, ID, PCB/BOM, serial, status). Queries SoC via UART4 cmd 0x21. |
+| `somwork` | Get SoC kernel work status ("Normal"/"Abnormal"). Based on keepalive responses. |
+| `temp-g` | Get CPU temperature, NPU temperature, and fan speed from SoC via UART4 cmd 0x0C. |
+
+### System
+
+| Command | Description |
+|---------|-------------|
+| `version` | Display BMC firmware version (format: `version:0x%x`) |
+| `reboot` | Reboot the BMC MCU |
+
+## Appendix: Original firmware verification
+
+The original ESWIN firmware (`STM32F407VET6_BMC.elf` from
+https://github.com/sifiveinc/hifive-premier-p550-tools) is not stripped and
+contains full symbol names. The following confirms pin assignments by
+cross-referencing function disassembly against GPIO register addresses.
+
+### GPIO port base addresses (from MX_GPIO_Init literal pool)
+
+| Address | Port |
+|---------|------|
+| 0x40020000 | GPIOA |
+| 0x40020400 | GPIOB |
+| 0x40020800 | GPIOC |
+| 0x40020C00 | GPIOD |
+| 0x40021000 | GPIOE |
+
+### Pin verification from named functions
+
+| Function | Port (from disasm) | Pin bitmask | GPIO Pin | Confirmed |
+|----------|-------------------|-------------|----------|-----------|
+| `atx_power_on` | 0x40021000 (GPIOE) | 0x08 | **PE3** | ATX power control |
+| `dc_power_on` | 0x40020C00 (GPIOD) | 0x10 | **PD4** | DC power control |
+| `get_dc_power_status` | 0x40021000 (GPIOE) | 0x20 | **PE5** | DC power good input |
+| `power_led_on` | 0x40020C00 (GPIOD) | 0x400 | **PD10** | Chassis power LED |
+| `sleep_led_on` | 0x40020C00 (GPIOD) | 0x800 | **PD11** | Chassis sleep LED |
+| `som_reset_control` | 0x40020C00 (GPIOD) | 0x20 | **PD5** | SOM warm reset |
+| `set_bootsel` | 0x40020C00 (GPIOD) | 0x0F | **PD0-PD3** | Boot mode select |
+| `get_key_status` | 0x40020000 (GPIOA) | 0x1000 | **PA12** | Power button |
+| `get_user_key_status` | 0x40020400 (GPIOB) | 0x02 | **PB1** | Recovery button |
+| `prvCommandCBWpEEPROM` | 0x40020800 (GPIOC) | 0x100 | **PC8** | EEPROM write protect |
+
+### MX_GPIO_Init initial pin states
+
+| Port.Pin | Initial State | Mode | Notes |
+|----------|--------------|------|-------|
+| PE3, PE15 | LOW | Output PP | ATX off, PE15 off at init |
+| PC0 | LOW | Output PP | Ethernet PHY reset asserted |
+| PB15 | LOW | Output PP | UART mux = SoC direct |
+| PD4, PD5, PD10 | LOW | Output PP | DC off, SOM reset asserted, power LED off |
+| PD11 | HIGH | Output PP | Sleep LED on at init |
+| PC8 | HIGH | Output PP | EEPROM write-protected at init |
+| PD0-PD3 | HIGH | Output PP | Boot select all high at init |
+| PA4 | HIGH | Output PP | SPI1 NSS deselected |
+| PA12 | - | IT_FALLING | Power button interrupt |
+| PD6 | - | IT_FALLING | SOM reset feedback interrupt |
+| PB1 | - | IT_FALLING | Recovery button interrupt |
+| PE5 | - | Input | DC power good (polled, not interrupt) |
+
+### NVIC interrupt mapping
+
+| IRQ | EXTI Line | GPIO Pin | Handler |
+|-----|-----------|----------|---------|
+| 7 | EXTI1 | PB1 | Recovery button (10s hold = factory reset) |
+| 23 | EXTI9_5 | PD6 | SOM reset feedback |
+| 40 | EXTI15_10 | PA12 | Power button (short=toggle, 4s hold=force off) |
+
+### Timer PWM configuration (from HAL_TIM_MspPostInit)
+
+| Timer | Peripheral | GPIO Port | Pin Bitmask | Pins | AF | Function |
+|-------|-----------|-----------|-------------|------|----|----------|
+| TIM1 | 0x40010000 | GPIOE (0x40021000) | 0x2A00 | PE9, PE11, PE13 | AF2 | RGB status LED (CH1=red, CH2=green, CH3=blue) |
+| TIM4 | 0x40000800 | GPIOD (0x40020C00) | 0x3000 | PD12, PD13 | AF2 | Fan PWM (CH1=CPU fan, CH2=chassis fan) |
+
+### RGB LED status codes (from set_mcu_led_status)
+
+| Status | Color | Meaning |
+|--------|-------|---------|
+| 1 | Red only | System off / power failure |
+| 2 | Green only | System running normally |
+| 3 | Blue / cycling | Boot in progress |
+| 4 | White (all) | All LEDs on |
+
+### I2C peripheral mapping
+
+| Handle (RAM) | Peripheral | Address | Bus | Confirmed usage |
+|-------------|-----------|---------|-----|-----------------|
+| 0x20000b34 | 0x40005400 (I2C1) | - | I2C1 | EEPROM access (0xA0 = 7-bit 0x50) via `es_check_carrier_board_info` |
+| 0x20000b88 | 0x40005C00 (I2C3) | - | I2C3 | INA226 (0x88 = 7-bit 0x44) via `ina226_init` |
+
+### INA226 configuration (from ina226_init)
+
+- Config register (0x00): **0x4527** (stored as LE 0x2745, byte-swapped on I2C) = 16 averages, 1.1ms bus+shunt conversion, continuous shunt+bus mode
+- Calibration register (0x05): **0x0800** (stored as LE 0x0008, byte-swapped on I2C) = 2048, giving Current_LSB = 2.5 mA with 1 mΩ shunt
+- Shunt resistor: **1 mΩ**, max measurable current ~81.9 A
+- I2C bus: **I2C3** (PA8 SCL, PC9 SDA)
+
+### Original firmware CLI commands (from strings)
+
+| Command | Description |
+|---------|-------------|
+| `sompower-g` | Get SOM power status (ON/OFF) |
+| `sompower-s` | Set SOM power (on/off) |
+| `somconsole-g` | Get SOM console config (UART/Telnet) |
+| `somconsole-s` | Set SOM console (0=UART, 1=Telnet) |
+| `bootsel-g` | Get software boot select configuration |
+| `bootsel-s` | Set software boot select |
+| `powerlost-g` | Get power-lost resume attribute |
+| `powerlost-s` | Set power-lost resume (enable/disable auto restart) |
+| `eepromwp-s` | Set EEPROM write protect (0=disabled, 1=enabled) |
+| `sominfo` | Display SOM board information |
+| `somwork` | Get SOM kernel work status |
+| `version` | Get BMC firmware version |


### PR DESCRIPTION
Add P550_BMC_HARDWARE.md documenting the complete STM32F407VET6 pin map for the HiFive Premier P550 carrier board, verified against both the carrier board schematic v3.1 and reverse engineering of the original ESWIN firmware ELF. Includes:

- Complete GPIO pin assignments (implemented and unimplemented)
- TMUX1574 mux designators: U77 for I2C routing, U70 for JTAG
- Carrier board EEPROM structure (AT24C02C on I2C1, dual-copy CRC32)
- MCU-SoC UART4 binary protocol (packet format, commands, checksum)
- Power sequencing from original firmware (on/off/reset sequences)
- INA226 power monitor config (1 mΩ shunt, CAL=2048, I2C byte order)
- Fan PWM (TIM4), boot mode strapping (EIC7700X), front panel LEDs
- DVB-1 vs DVB-2 board revision differences
- Original firmware CLI command reference
- DTS snippets and implementation notes for missing features

(I have not yet confirmed the data by plumbing up the settings, that's for a future PR)