### PR TITLE
ci: use generic ubuntu runners rather than TT ones

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   check-spdx:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check SPDX licenses
         uses: tenstorrent/tt-github-actions/.github/actions/spdx-checker@main
         with:
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: wallabmc
 
@@ -56,7 +56,7 @@ jobs:
         run: mkdir workspace
 
       - name: Cache West Modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         env:
           cache-name: cache-zephyr-modules
         with:
@@ -101,7 +101,7 @@ jobs:
 
       - name: Upload Board Firmware
         if: ${{ matrix.board != 'qemu_cortex_m3' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wallabmc-firmware-${{ matrix.board }}
           path: |
@@ -116,7 +116,7 @@ jobs:
 
       - name: Upload QEMU Firmware
         if: ${{ matrix.board == 'qemu_cortex_m3' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wallabmc-firmware-${{ matrix.board }}
           path: |
@@ -131,7 +131,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: wallabmc
 
@@ -141,7 +141,7 @@ jobs:
           sudo apt-get install -qq telnet qemu-system-arm
 
       - name: Download QEMU Firmware
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: wallabmc-firmware-qemu_cortex_m3
           path: firmware

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: zephyrprojectrtos/ci:v0.28.9
+      image: zephyrprojectrtos/ci:v0.29.0
 
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,7 @@ jobs:
   build:
     needs: check-spdx
 
-    # ubuntu-latest does not have enough space, use a large TT runner
-    runs-on: tt-ubuntu-2404-large-stable
+    runs-on: ubuntu-latest
     container:
       image: zephyrprojectrtos/ci:v0.28.9
 
@@ -125,8 +124,7 @@ jobs:
             workspace/build/zephyr/zephyr.elf
 
   test:
-    # ubuntu-latest does not have enough space, use a large TT runner
-    runs-on: tt-ubuntu-2404-large-stable
+    runs-on: ubuntu-latest
 
     needs: build
     if: needs.build.result == 'success'


### PR DESCRIPTION
This means anyone can run ci.  Fixes #4 