### PR TITLE
ci: Use the repo cache image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: zephyrprojectrtos/ci:v0.29.0
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.0.20260314
 
     strategy:
       matrix:
@@ -76,7 +76,7 @@ jobs:
           west init -l ../wallabmc
 
           # Update modules (fetches Zephyr kernel, HAL_STM32, etc.)
-          west update --narrow -o=--depth=10000 -o=--tags
+          west update --path-cache /repo-cache/zephyrproject --narrow -o=--depth=10000 -o=--tags
 
       - name: Build WallaBMC (sysbuild boards)
         if: ${{ matrix.board != 'qemu_cortex_m3' }}


### PR DESCRIPTION
Use the zephyr repo cache CI image.

This image contains clones of zephyr, and all other repos we need inside the docker image, meaning they don't have to be cloned from github.

This should make builds a bit more reliable against network glitches, at least once the container is up and running.

Cuts the west workspace initialisation down from several minutes to under a minute.

Total build time is only reduced by ~1 minute, because pulling the container takes longer.

Over time we'll need to update the tag version. Looking at upstream zephyr they do that manually, rather than following latest, so presumably we should do the same.