### PR TITLE
redfish, web: Add wallabmc and zephyr git SHA1 to web GUI

### DIFF
--- a/src/redfish.c
+++ b/src/redfish.c
@@ -767,6 +767,21 @@ REDFISH_HANDLER(managers_collection, "/redfish/v1/Managers",
 		managers_collection_get_handler, NULL, NULL);
 
 /*** /redfish/v1/Managers/bmc ***/
+struct redfish_manager_oem_wallabmc {
+	const char *zephyr_version;
+};
+static const struct json_obj_descr manager_oem_wallabmc_descr[] = {
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_manager_oem_wallabmc,
+				   "ZephyrVersion", zephyr_version,
+				   JSON_TOK_STRING),
+};
+struct redfish_manager_oem {
+	struct redfish_manager_oem_wallabmc wallabmc;
+};
+static const struct json_obj_descr manager_oem_descr[] = {
+	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_manager_oem, "WallaBMC",
+				     wallabmc, manager_oem_wallabmc_descr),
+};
 struct redfish_manager {
 	const char *odata_id;
 	const char *odata_type;
@@ -774,6 +789,8 @@ struct redfish_manager {
 	const char *name;
 	const char *uuid;
 	const char *date_time;
+	const char *firmware_version;
+	struct redfish_manager_oem oem;
 	struct redfish_link ethernet_interfaces;
 };
 static const struct json_obj_descr manager_descr[] = {
@@ -783,6 +800,8 @@ static const struct json_obj_descr manager_descr[] = {
 	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_manager, "Name", name, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_manager, "UUID", uuid, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_manager, "DateTime", date_time, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_manager, "FirmwareVersion", firmware_version, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_manager, "Oem", oem, manager_oem_descr),
 	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_manager, "EthernetInterfaces", ethernet_interfaces, link_descr),
 };
 
@@ -833,6 +852,8 @@ static int manager_get_handler(struct http_resource_user_data *user_data)
 		.uuid = NULL,
 		.name = "WallaBMC",
 		.date_time = get_iso_time(),
+		.firmware_version = PROJECT_GIT_SHA,
+		.oem = { .wallabmc = { .zephyr_version = BANNER_VERSION } },
 		.ethernet_interfaces = {
 			.odata_id = "/redfish/v1/Managers/bmc/EthernetInterfaces",
 		},

--- a/static_web_resources/index.html
+++ b/static_web_resources/index.html
@@ -392,6 +392,14 @@
 						<span class="info-item-label">Name</span>
 						<span class="data-value" id="bmc-name">Loading...</span>
 					</div>
+					<div class="info-item">
+						<span class="info-item-label">WallaBMC Version</span>
+						<span class="data-value" id="bmc-firmware-version">Loading...</span>
+					</div>
+					<div class="info-item">
+						<span class="info-item-label">Zephyr Version</span>
+						<span class="data-value" id="bmc-zephyr-version">Loading...</span>
+					</div>
 				</div>
 
 				<h3>Security</h3>
@@ -749,6 +757,8 @@
 
 			setText('bmc-uuid', bmcData.UUID);
 			setText('bmc-name', bmcData.Name);
+			setText('bmc-firmware-version', bmcData.FirmwareVersion);
+			setText('bmc-zephyr-version', bmcData.Oem && bmcData.Oem.WallaBMC && bmcData.Oem.WallaBMC.ZephyrVersion);
 
 			const bmc_date = new Date(bmcData.DateTime);
 			setText('bmc-date-time', bmc_date.toLocaleString(undefined,


### PR DESCRIPTION
Expose the wallabmc and zephyr git SHA1s via the Redfish Manager resource as FirmwareVersion and ZephyrVersion fields, and display them in the BMC section of the web dashboard.

The wallabmc SHA1 is already captured at build time via PROJECT_GIT_SHA. Add equivalent ZEPHYR_GIT_SHA by running git-describe on ZEPHYR_BASE during the CMake configure step.

Assisted-by: Claude Sonnet 4.6

<img width="1033" height="177" alt="image" src="https://github.com/user-attachments/assets/52d61d70-d0ca-4903-af4e-bcead51841fd" />
