### PR TITLE
Add vpd shell command

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -8,7 +8,6 @@
 LOG_MODULE_REGISTER(wallabmc, LOG_LEVEL_INF);
 
 #include <zephyr/kernel.h>
-#include <zephyr/version.h>
 #include <zephyr/sys/reboot.h>
 #include <zephyr/sys/poweroff.h>
 #include <zephyr/shell/shell.h>
@@ -32,13 +31,6 @@ bool is_boot_finished(void)
 {
 	return boot_finished;
 }
-
-/* Taken from zephyr/kernel/banner.c */
-#if defined(BUILD_VERSION) && !IS_EMPTY(BUILD_VERSION)
-#define BANNER_VERSION STRINGIFY(BUILD_VERSION)
-#else
-#define BANNER_VERSION KERNEL_VERSION_STRING
-#endif /* BUILD_VERSION */
 
 static void print_banner(void)
 {

--- a/src/vpd.c
+++ b/src/vpd.c
@@ -11,6 +11,36 @@ LOG_MODULE_REGISTER(wallabmc_vpd, LOG_LEVEL_INF);
 
 #include "vpd.h"
 
+#ifdef CONFIG_SHELL
+#include <zephyr/shell/shell.h>
+#include <zephyr/sys/util.h>
+
+static int cmd_vpd_show(const struct shell *sh, size_t argc, char **argv)
+{
+	const char *uuid;
+	int ret;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	ret = get_bmc_uuid_string(&uuid);
+	if (ret < 0) {
+		shell_error(sh, "Could not get BMC UUID (err=%d)", ret);
+		return ret;
+	}
+
+	shell_print(sh, "BMC UUID: %s", uuid);
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_vpd_cmds,
+	SHELL_CMD(show, NULL, "Show VPD.", cmd_vpd_show),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_CMD_REGISTER(vpd, &sub_vpd_cmds, "Vital product data", NULL);
+#endif /* CONFIG_SHELL */
+
 #ifdef CONFIG_APP_BMC_UUID
 static char bmc_uuid_str[UUID_STR_LEN];
 #else

--- a/src/vpd.c
+++ b/src/vpd.c
@@ -8,6 +8,7 @@ LOG_MODULE_REGISTER(wallabmc_vpd, LOG_LEVEL_INF);
 
 #include <zephyr/sys/uuid.h>
 #include <zephyr/drivers/hwinfo.h>
+#include <zephyr/version.h>
 
 #include "vpd.h"
 
@@ -30,6 +31,8 @@ static int cmd_vpd_show(const struct shell *sh, size_t argc, char **argv)
 	}
 
 	shell_print(sh, "BMC UUID: %s", uuid);
+	shell_print(sh, "BMC version: %s", PROJECT_GIT_SHA);
+	shell_print(sh, "BMC Zephyr version: %s", BANNER_VERSION);
 	return 0;
 }
 

--- a/src/vpd.h
+++ b/src/vpd.h
@@ -5,6 +5,15 @@
 #ifndef __VPD_H__
 #define __VPD_H__
 
+#include <zephyr/version.h>
+
+/* Taken from zephyr/kernel/banner.c */
+#if defined(BUILD_VERSION) && !IS_EMPTY(BUILD_VERSION)
+#define BANNER_VERSION STRINGIFY(BUILD_VERSION)
+#else
+#define BANNER_VERSION KERNEL_VERSION_STRING
+#endif /* BUILD_VERSION */
+
 int get_bmc_uuid_string(const char **str);
 int vpd_init(void);
 


### PR DESCRIPTION
Depends on #23 

Add a `vpd` shell command, with a `show` subcommand, that shows the UUID, firmware and zephyr version.