### PR TITLE
trivial rtc: Remove unnecessary static qualifier from local struct tm

### DIFF
--- a/src/rtc.c
+++ b/src/rtc.c
@@ -64,7 +64,7 @@ int rtc_set_from_clock(void)
 
 static int time_iso_to_ts(const char *str, struct timespec *ts)
 {
-	static struct tm tm;
+	struct tm tm;
 	int year, month, day, hour, minute, second, frac, ms;
 	time_t epoch_sec;
 	int ret;


### PR DESCRIPTION
The struct tm in time_iso_to_ts() is declared static but is fully zeroed via memset before every use, making the static qualifier unnecessary. Worse, it introduces a potential data race if the function is ever called concurrently from multiple threads.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Signed-off-by: Michael Neuling <mikey@neuling.org>