### PR TITLE
Add prek pre commit configuration to check for SoB etc.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
+
+repos:
+  - repo: local
+    hooks:
+      - id: check-git-signoff
+        name: Verify Signed-off-by (Allow WIP/wip & fixup)
+        language: system
+        entry: python3 scripts/check_signoff.py
+        stages: [commit-msg]
+  - repo: builtin
+    hooks:
+      - id: trailing-whitespace
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: end-of-file-fixer
+      - id: fix-byte-order-marker
+      - id: check-json
+      - id: check-yaml
+      - id: check-symlinks
+      - id: check-merge-conflict

--- a/scripts/check_signoff.py
+++ b/scripts/check_signoff.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+import subprocess
+import sys
+
+
+def main():
+    msg_file = sys.argv[1]
+    with open(msg_file) as f:
+        msg = f.read()
+
+    if re.match(r'^(wip|fixup)', msg, re.IGNORECASE):
+        sys.exit(0)
+
+    name = subprocess.check_output(['git', 'config', 'user.name']).decode().strip()
+    email = subprocess.check_output(['git', 'config', 'user.email']).decode().strip()
+    expected = f'Signed-off-by: {name} <{email}>'
+
+    if expected not in msg:
+        print(f'ERROR: Sign-off missing or incorrect. Expected: {expected}')
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add pre-commit hook configuration for use with "prek" [1].

Does nothing unless the user has prek installed.

Check for SoB tag, unless the commit messages starts with WIP or fixup.

Also run some other checks that are built into prek and check for bad things like trailing whitespace etc.

1: https://prek.j178.dev/