### PR TITLE
build: Rework PROJECT_GIT_SHA generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,26 +17,6 @@ else()
 	endif()
 endif()
 
-# Get project git SHA1 if not provided via CMake variable
-if(NOT DEFINED PROJECT_GIT_SHA)
-	# Use the shell script to get git SHA1
-	find_program(BASH_EXECUTABLE bash)
-	if(BASH_EXECUTABLE)
-		execute_process(
-			COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/get_project_git_sha.sh ${CMAKE_CURRENT_SOURCE_DIR}
-			OUTPUT_VARIABLE PROJECT_GIT_SHA
-			OUTPUT_STRIP_TRAILING_WHITESPACE
-			ERROR_QUIET
-		)
-	endif()
-	# Fallback to "unknown" if script didn't work
-	if(NOT DEFINED PROJECT_GIT_SHA OR PROJECT_GIT_SHA STREQUAL "")
-		set(PROJECT_GIT_SHA "unknown")
-	endif()
-endif()
-
-# Define project git SHA1 as compile-time string constant
-target_compile_definitions(app PRIVATE PROJECT_GIT_SHA="${PROJECT_GIT_SHA}")
 
 zephyr_linker_sources(SECTIONS sections-rom.ld)
 zephyr_linker_section_ifdef(CONFIG_HTTP_SERVER
@@ -50,6 +30,20 @@ zephyr_linker_section_ifdef(CONFIG_HTTP_SERVER
 
 # Used for webserver resources
 set(gen_dir ${ZEPHYR_BINARY_DIR}/include/generated/)
+
+# Generate git SHA header at build time so it stays current across commits
+find_program(BASH_EXECUTABLE bash)
+set(git_sha_header ${gen_dir}/git_sha.h)
+add_custom_target(app_git_sha ALL
+	COMMAND ${CMAKE_COMMAND}
+		-DBASH_EXECUTABLE=${BASH_EXECUTABLE}
+		-DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+		-DOUTPUT_FILE=${git_sha_header}
+		-P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/gen_git_sha.cmake
+	BYPRODUCTS ${git_sha_header}
+	COMMENT "Generating git SHA header"
+)
+add_dependencies(app app_git_sha)
 
 target_sources(app PRIVATE
 	src/config.c

--- a/cmake/gen_git_sha.cmake
+++ b/cmake/gen_git_sha.cmake
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: © 2025-2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generates git_sha.h at build time so the SHA reflects the current commit.
+# Only writes the file when the SHA changes to avoid unnecessary recompilation.
+# Invoked via add_custom_target with -DBASH_EXECUTABLE, -DSOURCE_DIR, -DOUTPUT_FILE.
+
+if(BASH_EXECUTABLE)
+	execute_process(
+		COMMAND ${BASH_EXECUTABLE} ${SOURCE_DIR}/scripts/get_project_git_sha.sh ${SOURCE_DIR}
+		OUTPUT_VARIABLE sha
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+		ERROR_QUIET
+	)
+endif()
+
+if(NOT sha OR sha STREQUAL "")
+	set(sha "unknown")
+endif()
+
+set(content "#pragma once\n#define PROJECT_GIT_SHA \"${sha}\"\n")
+if(EXISTS "${OUTPUT_FILE}")
+	file(READ "${OUTPUT_FILE}" existing)
+	if(existing STREQUAL content)
+		return()
+	endif()
+endif()
+file(WRITE "${OUTPUT_FILE}" "${content}")

--- a/src/main.c
+++ b/src/main.c
@@ -25,6 +25,7 @@ LOG_MODULE_REGISTER(wallabmc, LOG_LEVEL_INF);
 #include "console_bridge.h"
 #include "console_bridge_ws.h"
 #include "vpd.h"
+#include "git_sha.h"
 
 static bool boot_finished = false;
 

--- a/src/redfish.c
+++ b/src/redfish.c
@@ -29,6 +29,7 @@
 #include "rtc.h"
 #include "sensors.h"
 #include "vpd.h"
+#include "git_sha.h"
 
 LOG_MODULE_REGISTER(redfish_app, CONFIG_LOG_DEFAULT_LEVEL);
 

--- a/src/vpd.c
+++ b/src/vpd.c
@@ -11,6 +11,7 @@ LOG_MODULE_REGISTER(wallabmc_vpd, LOG_LEVEL_INF);
 #include <zephyr/version.h>
 
 #include "vpd.h"
+#include "git_sha.h"
 
 #ifdef CONFIG_SHELL
 #include <zephyr/shell/shell.h>


### PR DESCRIPTION
The current method of generating PROJECT_GIT_SHA doesn't always work for incremental builds.

You can see this with:

    $ west build ...
    $ rg PROJECT_GIT_SHA | head -1
    # note the value of PROJECT_GIT_SHA
    $ git commit --allow-empty -m Empty
    $ west build ...
    $ rg PROJECT_GIT_SHA | head -1
    # note the value of PROJECT_GIT_SHA has not changed

Fix it by generating the SHA into a header at build time, and including the header in the files that require it.

Assisted-by: Claude:sonnet-4.6