### PR TITLE
west: Use Zephyr v4.4.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -6,7 +6,7 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyr
-      revision: main
+      revision: v4.4.0
       import: true
 
   self:


### PR DESCRIPTION
Now that there's a recent Zephyr release, pin to that version in west.yml.

This should prevent CI from breaking randomly when Zephyr changes are merged that need some rework in wallabmc.

From now on we will have to intentionally update the Zephyr version semi-regularly.