### PR TITLE
Add clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,21 @@
+BasedOnStyle: LLVM
+IndentWidth: 8
+TabWidth: 8
+ContinuationIndentWidth: 8
+UseTab: Always
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: true
+  SplitEmptyFunction: false
+  SplitEmptyNamespace: true
+AlignConsecutiveMacros: true
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+IndentCaseLabels: false
+SpaceBeforeParens: ControlStatements
+ColumnLimit: 100
+BreakStringLiterals: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,20 @@ jobs:
           verbose: 'true'
           ignore_config_file: .github/spdx-ignore.yaml
 
+  check-clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install clang-format 20.1.8
+        uses: aminya/setup-cpp@v1
+        with:
+          clang-format: 20.1.8
+      - name: Check clang-format
+        run: |
+          find src -name '*.c' -o -name '*.h' | xargs clang-format --dry-run --Werror
+
   build:
-    needs: check-spdx
+    needs: [check-spdx, check-clang-format]
 
     runs-on: ubuntu-latest
     container:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,9 @@ repos:
       - id: check-yaml
       - id: check-symlinks
       - id: check-merge-conflict
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: "v20.1.8"
+    hooks:
+      - id: clang-format
+        types_or: [c]
+        files: \.(h|c)$

--- a/src/button.c
+++ b/src/button.c
@@ -8,21 +8,20 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(wallabmc_button, LOG_LEVEL_INF);
 
-#include <zephyr/kernel.h>
+#include <inttypes.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
-#include <inttypes.h>
 
 #include "button.h"
-#include "main.h"
 #include "config.h"
+#include "main.h"
 
-#define USER_BUTTON_NODE	DT_ALIAS(reset_button)
+#define USER_BUTTON_NODE DT_ALIAS(reset_button)
 #if DT_NODE_HAS_STATUS_OKAY(USER_BUTTON_NODE)
 
-static const struct gpio_dt_spec button = GPIO_DT_SPEC_GET_OR(USER_BUTTON_NODE, gpios,
-							      {0});
+static const struct gpio_dt_spec button = GPIO_DT_SPEC_GET_OR(USER_BUTTON_NODE, gpios, {0});
 
 static void reset_work_fn(struct k_work *work)
 {
@@ -66,8 +65,7 @@ static K_WORK_DELAYABLE_DEFINE(button_work, button_work_fn);
 
 static struct gpio_callback button_cb_data;
 
-static void button_pressed(const struct device *dev,
-			   struct gpio_callback *cb, uint32_t pins)
+static void button_pressed(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
 {
 	k_work_schedule(&button_work, K_MSEC(DEBOUNCE_TIME_MS));
 }
@@ -77,8 +75,7 @@ int button_init(void)
 	int ret;
 
 	if (!gpio_is_ready_dt(&button)) {
-		LOG_ERR("Error: button device %s is not ready",
-			button.port->name);
+		LOG_ERR("Error: button device %s is not ready", button.port->name);
 		return -ENOSYS;
 	}
 

--- a/src/config.c
+++ b/src/config.c
@@ -6,20 +6,20 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(wallabmc_config, LOG_LEVEL_INF);
 
-#include <zephyr/shell/shell.h>
-#include <stdlib.h>
 #include <ctype.h>
-#include <zephyr/sys/util.h>
+#include <stdlib.h>
 #include <zephyr/kernel.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/sys/util.h>
 
 #include <zephyr/net/hostname.h>
 #include <zephyr/posix/arpa/inet.h> /* inet_ntop */
 
 #include "config.h"
+#include "fs.h"
 #include "main.h"
 #include "net.h"
 #include "ntp.h"
-#include "fs.h"
 
 #define MAX_HOSTNAME_LEN 20
 
@@ -31,16 +31,17 @@ LOG_MODULE_REGISTER(wallabmc_config, LOG_LEVEL_INF);
 #define CFG_CURRENT_VERSION 3
 
 enum config_id {
-	CFG_VERSION = 1,			/* uint8_t */
-	CFG_BMC_ADMIN_PASSWORD = 2,		/* C string */
-	CFG_BMC_HOSTNAME = 3,		/* C string */
-	CFG_BMC_DEFAULT_IP4 = 4,		/* uint32_t */
-	CFG_BMC_DEFAULT_IP4_NM = 5,		/* uint32_t */
-	CFG_BMC_DEFAULT_IP4_GW = 6,		/* uint32_t */
-	CFG_BMC_USE_DHCP4 = 7,		/* uint8_t */
-	CFG_BMC_USE_NTP = 8,			/* uint8_t */
-	CFG_BMC_NTP_SERVER = 9,		/* C string */
-	CFG_HOST_AUTO_POWERON = 10,		/* uint8_t */
+	CFG_VERSION = 1,	    /* uint8_t */
+	CFG_BMC_ADMIN_PASSWORD = 2, /* C string */
+	CFG_BMC_HOSTNAME = 3,	    /* C string */
+	CFG_BMC_DEFAULT_IP4 = 4,    /* uint32_t */
+	CFG_BMC_DEFAULT_IP4_NM = 5, /* uint32_t */
+	CFG_BMC_DEFAULT_IP4_GW = 6, /* uint32_t */
+	CFG_BMC_USE_DHCP4 = 7,	    /* uint8_t */
+	CFG_BMC_USE_NTP = 8,	    /* uint8_t */
+	CFG_BMC_NTP_SERVER = 9,	    /* C string */
+	CFG_HOST_AUTO_POWERON = 10, /* uint8_t */
+
 	/*
 	 * Add field IDs in increasing order and do not reuse deprecated
 	 * ones. Do not change meaning but add new and deprecate old.
@@ -103,75 +104,38 @@ static ssize_t __config_write(uint16_t id, const void *buf, size_t size)
 	return -ENODEV;
 }
 
-#define config_read(id, var)				\
-({							\
-	__config_read(id, &var, sizeof(var));		\
-})
+#define config_read(id, var) ({ __config_read(id, &var, sizeof(var)); })
 
-#define config_read_str(id, var)			\
-({							\
-	ssize_t rc;					\
-	rc = __config_read(id, var, sizeof(var) - 1);	\
-	if (rc >= 0)					\
-		var[rc] = '\0';				\
-	rc;						\
-})
+#define config_read_str(id, var)                                                                   \
+	({                                                                                         \
+		ssize_t rc;                                                                        \
+		rc = __config_read(id, var, sizeof(var) - 1);                                      \
+		if (rc >= 0)                                                                       \
+			var[rc] = '\0';                                                            \
+		rc;                                                                                \
+	})
 
-#define config_write(id, var)				\
-({							\
-	__config_write(id, &var, sizeof(var));		\
-})
+#define config_write(id, var) ({ __config_write(id, &var, sizeof(var)); })
 
-#define config_write_str(id, var)			\
-({							\
-	__config_write(id, var, strlen(var));		\
-})
+#define config_write_str(id, var) ({ __config_write(id, var, strlen(var)); })
 
+const char *config_bmc_hostname(void) { return config_data.bmc_hostname; }
 
-const char *config_bmc_hostname(void)
-{
-	return config_data.bmc_hostname;
-}
+uint32_t config_bmc_default_ip4(void) { return config_data.bmc_default_ip4; }
 
-uint32_t config_bmc_default_ip4(void)
-{
-	return config_data.bmc_default_ip4;
-}
+uint32_t config_bmc_default_ip4_nm(void) { return config_data.bmc_default_ip4_nm; }
 
-uint32_t config_bmc_default_ip4_nm(void)
-{
-	return config_data.bmc_default_ip4_nm;
-}
+uint32_t config_bmc_default_ip4_gw(void) { return config_data.bmc_default_ip4_gw; }
 
-uint32_t config_bmc_default_ip4_gw(void)
-{
-	return config_data.bmc_default_ip4_gw;
-}
+bool config_bmc_use_dhcp4(void) { return config_data.bmc_use_dhcp4; }
 
-bool config_bmc_use_dhcp4(void)
-{
-	return config_data.bmc_use_dhcp4;
-}
+bool config_host_auto_poweron(void) { return config_data.host_auto_poweron; }
 
-bool config_host_auto_poweron(void)
-{
-	return config_data.host_auto_poweron;
-}
+const char *config_bmc_admin_password(void) { return config_data.bmc_admin_password; }
 
-const char *config_bmc_admin_password(void)
-{
-	return config_data.bmc_admin_password;
-}
+bool config_bmc_use_ntp(void) { return config_data.bmc_use_ntp; }
 
-bool config_bmc_use_ntp(void)
-{
-	return config_data.bmc_use_ntp;
-}
-
-const char *config_bmc_ntp_server(void)
-{
-	return config_data.bmc_ntp_server;
-}
+const char *config_bmc_ntp_server(void) { return config_data.bmc_ntp_server; }
 
 #if defined(CONFIG_APP_HTTPS_PSK)
 /*
@@ -180,7 +144,9 @@ const char *config_bmc_ntp_server(void)
  */
 bool config_bmc_https_psk(const char **psk, int *psk_len)
 {
-	static const char p[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, };
+	static const char p[] = {
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+	};
 
 	*psk = p;
 	*psk_len = sizeof(p);
@@ -206,8 +172,8 @@ int config_bmc_hostname_set(const char *hostname)
 	return 0;
 }
 
-#define CMD_HELP_BMC_HOSTNAME			\
-	"Configure BMC hostname\n"		\
+#define CMD_HELP_BMC_HOSTNAME                                                                      \
+	"Configure BMC hostname\n"                                                                 \
 	"Usage: bmc hostname <hostname>"
 
 static int cmd_config_bmc_hostname(const struct shell *sh, size_t argc, char **argv)
@@ -347,8 +313,8 @@ int config_bmc_default_ip4_gw_set(const char *str)
 	return 0;
 }
 
-#define CMD_HELP_BMC_DEFAULT_IP4		\
-	"Configure BMC default IPv4 address\n"	\
+#define CMD_HELP_BMC_DEFAULT_IP4                                                                   \
+	"Configure BMC default IPv4 address\n"                                                     \
 	"Usage: bmc ipv4_address <IPv4 address>"
 
 static int cmd_config_bmc_default_ip4(const struct shell *sh, size_t argc, char **argv)
@@ -373,8 +339,8 @@ static int cmd_config_bmc_default_ip4(const struct shell *sh, size_t argc, char 
 	return 0;
 }
 
-#define CMD_HELP_BMC_DEFAULT_IP4_NM			\
-	"Configure BMC default IPv4 subnet mask\n"	\
+#define CMD_HELP_BMC_DEFAULT_IP4_NM                                                                \
+	"Configure BMC default IPv4 subnet mask\n"                                                 \
 	"Usage: bmc ipv4_subnet_mask <IPv4 address>"
 
 static int cmd_config_bmc_default_ip4_nm(const struct shell *sh, size_t argc, char **argv)
@@ -399,8 +365,8 @@ static int cmd_config_bmc_default_ip4_nm(const struct shell *sh, size_t argc, ch
 	return 0;
 }
 
-#define CMD_HELP_BMC_DEFAULT_IP4_GW			\
-	"Configure BMC default IPv4 gateway\n"	\
+#define CMD_HELP_BMC_DEFAULT_IP4_GW                                                                \
+	"Configure BMC default IPv4 gateway\n"                                                     \
 	"Usage: bmc ipv4_gateway <IPv4 address>"
 
 static int cmd_config_bmc_default_ip4_gw(const struct shell *sh, size_t argc, char **argv)
@@ -450,8 +416,8 @@ int config_bmc_use_dhcp4_set(bool use)
 	return 0;
 }
 
-#define CMD_HELP_BMC_DHCP4			\
-	"BMC DHCP4 enabled\n"			\
+#define CMD_HELP_BMC_DHCP4                                                                         \
+	"BMC DHCP4 enabled\n"                                                                      \
 	"Usage: bmc dhcpv4 <enable|disable>"
 
 static int cmd_config_bmc_dhcp4(const struct shell *sh, size_t argc, char **argv)
@@ -502,8 +468,8 @@ int config_bmc_use_ntp_set(bool use)
 	return 0;
 }
 
-#define CMD_HELP_BMC_NTP				\
-	"BMC NTP time sync enabled\n"			\
+#define CMD_HELP_BMC_NTP                                                                           \
+	"BMC NTP time sync enabled\n"                                                              \
 	"Usage: bmc ntp <enable|disable>"
 
 static int cmd_config_bmc_ntp(const struct shell *sh, size_t argc, char **argv)
@@ -554,8 +520,8 @@ int config_bmc_ntp_server_set(const char *ntp_server)
 	return 0;
 }
 
-#define CMD_HELP_BMC_NTP_SERVER				\
-	"BMC NTP server address\n"			\
+#define CMD_HELP_BMC_NTP_SERVER                                                                    \
+	"BMC NTP server address\n"                                                                 \
 	"Usage: bmc ntp_server <server address>"
 
 static int cmd_config_bmc_ntp_server(const struct shell *sh, size_t argc, char **argv)
@@ -580,7 +546,6 @@ static int cmd_config_bmc_ntp_server(const struct shell *sh, size_t argc, char *
 	return 0;
 }
 
-
 int config_bmc_password_set(const char *password)
 {
 	int rc;
@@ -600,8 +565,8 @@ int config_bmc_password_set(const char *password)
 	return 0;
 }
 
-#define CMD_HELP_BMC_ADMIN_PASSWORD		\
-	"BMC admin password\n"			\
+#define CMD_HELP_BMC_ADMIN_PASSWORD                                                                \
+	"BMC admin password\n"                                                                     \
 	"Usage: bmc password <pw>"
 
 static int cmd_config_bmc_password(const struct shell *sh, size_t argc, char **argv)
@@ -626,17 +591,20 @@ static int cmd_config_bmc_password(const struct shell *sh, size_t argc, char **a
 	return 0;
 }
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_config_bmc_cmds,
-	SHELL_CMD_ARG(password,		NULL, CMD_HELP_BMC_ADMIN_PASSWORD, cmd_config_bmc_password, 2, 0),
-	SHELL_CMD_ARG(hostname,		NULL, CMD_HELP_BMC_HOSTNAME, cmd_config_bmc_hostname, 2, 0),
-	SHELL_CMD_ARG(ipv4_address,	NULL, CMD_HELP_BMC_DEFAULT_IP4, cmd_config_bmc_default_ip4, 2, 0),
-	SHELL_CMD_ARG(ipv4_subnet_mask,	NULL, CMD_HELP_BMC_DEFAULT_IP4_NM, cmd_config_bmc_default_ip4_nm, 2, 0),
-	SHELL_CMD_ARG(ipv4_gateway,	NULL, CMD_HELP_BMC_DEFAULT_IP4_GW, cmd_config_bmc_default_ip4_gw, 2, 0),
-	SHELL_CMD_ARG(dhcpv4,		NULL, CMD_HELP_BMC_DHCP4, cmd_config_bmc_dhcp4, 2, 0),
-	SHELL_CMD_ARG(ntp,		NULL, CMD_HELP_BMC_NTP, cmd_config_bmc_ntp, 2, 0),
-	SHELL_CMD_ARG(ntp_server,	NULL, CMD_HELP_BMC_NTP_SERVER, cmd_config_bmc_ntp_server, 2, 0),
-	SHELL_SUBCMD_SET_END
-);
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_config_bmc_cmds,
+	SHELL_CMD_ARG(password, NULL, CMD_HELP_BMC_ADMIN_PASSWORD, cmd_config_bmc_password, 2, 0),
+	SHELL_CMD_ARG(hostname, NULL, CMD_HELP_BMC_HOSTNAME, cmd_config_bmc_hostname, 2, 0),
+	SHELL_CMD_ARG(ipv4_address, NULL, CMD_HELP_BMC_DEFAULT_IP4, cmd_config_bmc_default_ip4, 2,
+		      0),
+	SHELL_CMD_ARG(ipv4_subnet_mask, NULL, CMD_HELP_BMC_DEFAULT_IP4_NM,
+		      cmd_config_bmc_default_ip4_nm, 2, 0),
+	SHELL_CMD_ARG(ipv4_gateway, NULL, CMD_HELP_BMC_DEFAULT_IP4_GW,
+		      cmd_config_bmc_default_ip4_gw, 2, 0),
+	SHELL_CMD_ARG(dhcpv4, NULL, CMD_HELP_BMC_DHCP4, cmd_config_bmc_dhcp4, 2, 0),
+	SHELL_CMD_ARG(ntp, NULL, CMD_HELP_BMC_NTP, cmd_config_bmc_ntp, 2, 0),
+	SHELL_CMD_ARG(ntp_server, NULL, CMD_HELP_BMC_NTP_SERVER, cmd_config_bmc_ntp_server, 2, 0),
+	SHELL_SUBCMD_SET_END);
 
 int config_host_auto_poweron_set(bool on)
 {
@@ -661,8 +629,8 @@ int config_host_auto_poweron_set(bool on)
 	return 0;
 }
 
-#define CMD_HELP_HOST_AUTO_POWERON		\
-	"Host auto poweron enabled\n"		\
+#define CMD_HELP_HOST_AUTO_POWERON                                                                 \
+	"Host auto poweron enabled\n"                                                              \
 	"Usage: host auto_poweron <enable|disable>"
 
 static int cmd_config_host_auto_poweron(const struct shell *sh, size_t argc, char **argv)
@@ -689,9 +657,9 @@ static int cmd_config_host_auto_poweron(const struct shell *sh, size_t argc, cha
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_config_host_cmds,
-	SHELL_CMD_ARG(auto_poweron,	NULL, CMD_HELP_HOST_AUTO_POWERON, cmd_config_host_auto_poweron, 2, 0),
-	SHELL_SUBCMD_SET_END
-);
+			       SHELL_CMD_ARG(auto_poweron, NULL, CMD_HELP_HOST_AUTO_POWERON,
+					     cmd_config_host_auto_poweron, 2, 0),
+			       SHELL_SUBCMD_SET_END);
 
 static int cmd_config_show(const struct shell *sh, size_t argc, char **argv)
 {
@@ -699,13 +667,14 @@ static int cmd_config_show(const struct shell *sh, size_t argc, char **argv)
 	ARG_UNUSED(argv);
 
 	shell_print(sh, "--- Configuration ---");
-	shell_print(sh, "BMC hostname: %s",	config_data.bmc_hostname);
+	shell_print(sh, "BMC hostname: %s", config_data.bmc_hostname);
 	shell_print(sh, "BMC default IPv4 address: %s", ip4_atos(config_data.bmc_default_ip4));
-	shell_print(sh, "BMC default IPv4 subnet mask: %s", ip4_atos(config_data.bmc_default_ip4_nm));
+	shell_print(sh, "BMC default IPv4 subnet mask: %s",
+		    ip4_atos(config_data.bmc_default_ip4_nm));
 	shell_print(sh, "BMC default IPv4 gateway: %s", ip4_atos(config_data.bmc_default_ip4_gw));
-	shell_print(sh, "BMC use DHCPv4: %d",	config_data.bmc_use_dhcp4);
-	shell_print(sh, "BMC use NTP: %d",	config_data.bmc_use_ntp);
-	shell_print(sh, "BMC NTP server: %s",	config_data.bmc_ntp_server);
+	shell_print(sh, "BMC use DHCPv4: %d", config_data.bmc_use_dhcp4);
+	shell_print(sh, "BMC use NTP: %d", config_data.bmc_use_ntp);
+	shell_print(sh, "BMC NTP server: %s", config_data.bmc_ntp_server);
 	shell_print(sh, "Host auto poweron: %d", config_data.host_auto_poweron);
 	shell_print(sh, "---------------------");
 
@@ -735,20 +704,17 @@ static int cmd_config_clear(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_config_cmds,
-	SHELL_CMD(show,	NULL, "Show configuration.", &cmd_config_show),
-	SHELL_CMD(bmc,	&sub_config_bmc_cmds, "BMC configuration commands.", NULL),
-	SHELL_CMD(host,	&sub_config_host_cmds, "Host configuration commands.", NULL),
-	SHELL_CMD(clear_and_reboot, NULL, "Clear configuration and reboot system.", &cmd_config_clear),
-	SHELL_SUBCMD_SET_END
-);
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_config_cmds, SHELL_CMD(show, NULL, "Show configuration.", &cmd_config_show),
+	SHELL_CMD(bmc, &sub_config_bmc_cmds, "BMC configuration commands.", NULL),
+	SHELL_CMD(host, &sub_config_host_cmds, "Host configuration commands.", NULL),
+	SHELL_CMD(clear_and_reboot, NULL, "Clear configuration and reboot system.",
+		  &cmd_config_clear),
+	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(config, &sub_config_cmds, "Configuration commands", NULL);
 
-int config_clear(void)
-{
-	return fs_clear();
-}
+int config_clear(void) { return fs_clear(); }
 
 int config_init(void)
 {
@@ -768,7 +734,8 @@ int config_init(void)
 			config_data.version = CFG_CURRENT_VERSION;
 			rc = config_write(CFG_VERSION, config_data.version);
 		} else if (config_data.version != CFG_CURRENT_VERSION) {
-			LOG_WRN("Config version unknown (version=%d), creating new config", config_data.version);
+			LOG_WRN("Config version unknown (version=%d), creating new config",
+				config_data.version);
 			rc = config_clear();
 			if (rc == 0) {
 				config_data.version = CFG_CURRENT_VERSION;
@@ -794,14 +761,16 @@ int config_init(void)
 	 */
 	rc = config_read_str(CFG_BMC_ADMIN_PASSWORD, config_data.bmc_admin_password);
 	if (rc < 0) {
-		strlcpy(config_data.bmc_admin_password, CONFIG_DEFAULT_ADMIN_PASSWORD, sizeof(config_data.bmc_admin_password));
+		strlcpy(config_data.bmc_admin_password, CONFIG_DEFAULT_ADMIN_PASSWORD,
+			sizeof(config_data.bmc_admin_password));
 		config_write_str(CFG_BMC_ADMIN_PASSWORD, config_data.bmc_admin_password);
 	}
 
 	rc = config_read_str(CFG_BMC_HOSTNAME, config_data.bmc_hostname);
 	if (rc < 0) {
 		/* Default to CONFIG_NET_HOSTNAME, which net_hostname_get() will return */
-		strlcpy(config_data.bmc_hostname, net_hostname_get(), sizeof(config_data.bmc_hostname));
+		strlcpy(config_data.bmc_hostname, net_hostname_get(),
+			sizeof(config_data.bmc_hostname));
 		config_write_str(CFG_BMC_HOSTNAME, config_data.bmc_hostname);
 	}
 
@@ -837,7 +806,8 @@ int config_init(void)
 
 	rc = config_read_str(CFG_BMC_NTP_SERVER, config_data.bmc_ntp_server);
 	if (rc < 0) {
-		strlcpy(config_data.bmc_ntp_server, "pool.ntp.org", sizeof(config_data.bmc_ntp_server));
+		strlcpy(config_data.bmc_ntp_server, "pool.ntp.org",
+			sizeof(config_data.bmc_ntp_server));
 		config_write_str(CFG_BMC_NTP_SERVER, config_data.bmc_ntp_server);
 	}
 

--- a/src/console_bridge.c
+++ b/src/console_bridge.c
@@ -3,24 +3,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- #include <zephyr/kernel.h>
+#include <zephyr/kernel.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(console_bridge, LOG_LEVEL_INF);
 
-#include <zephyr/posix/fcntl.h>
-#include <zephyr/net/socket.h>
 #include <errno.h>
-#include <unistd.h>
-#include <sys/socket.h>
 #include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/posix/fcntl.h>
 
 #include "console_logger.h"
 #include "synch.h"
 
-#define CONSOLE_BRIDGE_PORT 22
+#define CONSOLE_BRIDGE_PORT	  22
 #define CONSOLE_BRIDGE_STACK_SIZE K_THREAD_STACK_SIZEOF(console_bridge_stack_area)
-#define CONSOLE_BRIDGE_PRIORITY   CONFIG_CONSOLE_BRIDGE_PRIORITY
+#define CONSOLE_BRIDGE_PRIORITY	  CONFIG_CONSOLE_BRIDGE_PRIORITY
 
 K_THREAD_STACK_DEFINE(console_bridge_stack_area, CONFIG_CONSOLE_BRIDGE_STACK_SIZE);
 static struct k_thread console_bridge_thread_data;
@@ -57,10 +57,8 @@ static void socket_send_thread(void *a, void *b, void *c)
 		if (ret < 0)
 			continue;
 		if (ret == 0) {
-			k_event_wait_safe(&events,
-					EVENT_TELNET_CLIENT |
-					EVENT_CONSOLE_LOG_DATA,
-					false, K_FOREVER);
+			k_event_wait_safe(&events, EVENT_TELNET_CLIENT | EVENT_CONSOLE_LOG_DATA,
+					  false, K_FOREVER);
 			continue;
 		}
 
@@ -158,8 +156,7 @@ static void console_bridge_daemon_thread(void *a, void *b, void *c)
 		socklen_t client_addr_len = sizeof(client_addr);
 		int client_fd;
 
-		client_fd = accept(server_fd, (struct sockaddr *)&client_addr,
-				   &client_addr_len);
+		client_fd = accept(server_fd, (struct sockaddr *)&client_addr, &client_addr_len);
 		if (client_fd < 0) {
 			LOG_ERR("accept() failed: %d", errno);
 			continue;
@@ -177,20 +174,17 @@ static void console_bridge_daemon_thread(void *a, void *b, void *c)
 
 int console_bridge_init(void)
 {
-	LOG_INF("Starting console bridge daemon (host console UART -> TCP port %d)...", CONSOLE_BRIDGE_PORT);
+	LOG_INF("Starting console bridge daemon (host console UART -> TCP port %d)...",
+		CONSOLE_BRIDGE_PORT);
 
 	k_thread_create(&console_bridge_thread_data, console_bridge_stack_area,
-			CONSOLE_BRIDGE_STACK_SIZE,
-			console_bridge_daemon_thread,
-			NULL, NULL, NULL,
+			CONSOLE_BRIDGE_STACK_SIZE, console_bridge_daemon_thread, NULL, NULL, NULL,
 			CONSOLE_BRIDGE_PRIORITY, 0, K_NO_WAIT);
 
 	k_thread_name_set(&console_bridge_thread_data, "console_bridge");
 
 	k_thread_create(&socket_send_thread_data, socket_send_thread_stack_area,
-			CONFIG_CONSOLE_BRIDGE_STACK_SIZE,
-			socket_send_thread,
-			NULL, NULL, NULL,
+			CONFIG_CONSOLE_BRIDGE_STACK_SIZE, socket_send_thread, NULL, NULL, NULL,
 			CONSOLE_BRIDGE_PRIORITY, 0, K_NO_WAIT);
 
 	k_thread_name_set(&socket_send_thread_data, "socket_send");

--- a/src/console_bridge_ws.c
+++ b/src/console_bridge_ws.c
@@ -7,22 +7,22 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(host_console_ws, LOG_LEVEL_INF);
 
-#include <zephyr/posix/fcntl.h>
-#include <zephyr/drivers/uart.h>
+#include <errno.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/net/http/server.h>
+#include <zephyr/net/http/service.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/socket_service.h>
-#include <zephyr/net/http/service.h>
-#include <zephyr/net/http/server.h>
 #include <zephyr/net/websocket.h>
-#include <errno.h>
-#include <unistd.h>
-#include <sys/socket.h>
-#include <string.h>
+#include <zephyr/posix/fcntl.h>
 
 #include "console_logger.h"
-#include "synch.h"
 #include "http.h"
+#include "synch.h"
 
 /*
  * Receive buffer size.
@@ -31,8 +31,8 @@ LOG_MODULE_REGISTER(host_console_ws, LOG_LEVEL_INF);
 #define WS_RX_BUF_SIZE 32
 
 struct host_websocket {
-        /** Array for sockets used by the websocket service. */
-        struct zsock_pollfd fds[1];
+	/** Array for sockets used by the websocket service. */
+	struct zsock_pollfd fds[1];
 	bool new_client;
 };
 
@@ -68,7 +68,8 @@ static ssize_t ws_send(struct host_websocket *ws, const void *buf, size_t size, 
 		 * closed.
 		 */
 		ret = websocket_send_msg(ws->fds[0].fd, (uint8_t *)buf + copied, size - copied,
-					 WEBSOCKET_OPCODE_DATA_BINARY, false, true, block ? SYS_FOREVER_MS : 0);
+					 WEBSOCKET_OPCODE_DATA_BINARY, false, true,
+					 block ? SYS_FOREVER_MS : 0);
 		if (ret < 0) {
 			if (errno == EAGAIN && !block)
 				return copied;
@@ -93,8 +94,8 @@ static ssize_t ws_recv(struct host_websocket *ws, void *buf, size_t size, bool b
 	uint32_t message_type;
 	uint64_t remaining;
 
-	ret = websocket_recv_msg(ws->fds[0].fd, buf, size,
-				&message_type, &remaining, block ? SYS_FOREVER_MS : 0);
+	ret = websocket_recv_msg(ws->fds[0].fd, buf, size, &message_type, &remaining,
+				 block ? SYS_FOREVER_MS : 0);
 	if (ret < 0) {
 		LOG_DBG("Websocket client error %d", ret);
 		if (errno == EAGAIN && !block)
@@ -140,16 +141,14 @@ static void socket_send_thread(void *a, void *b, void *c)
 		if (ret < 0)
 			continue;
 		if (ret == 0) {
-			k_event_wait_safe(&events,
-					EVENT_WEBSOCKET_CLIENT |
-					EVENT_CONSOLE_LOG_DATA,
-					false, K_FOREVER);
+			k_event_wait_safe(&events, EVENT_WEBSOCKET_CLIENT | EVENT_CONSOLE_LOG_DATA,
+					  false, K_FOREVER);
 			continue;
 		}
 
 		nr = ret;
 		copied = 0;
-again:
+	again:
 		if (ws->fds[0].fd == -1)
 			continue;
 
@@ -179,10 +178,9 @@ static void ws_server_cb(struct net_socket_service_event *evt)
 
 	ws = (struct host_websocket *)evt->user_data;
 
-	if ((evt->event.revents & ZSOCK_POLLERR) ||
-	    (evt->event.revents & ZSOCK_POLLNVAL)) {
-		(void)zsock_getsockopt(evt->event.fd, ZSOCK_SOL_SOCKET,
-				       ZSOCK_SO_ERROR, &sock_error, &optlen);
+	if ((evt->event.revents & ZSOCK_POLLERR) || (evt->event.revents & ZSOCK_POLLNVAL)) {
+		(void)zsock_getsockopt(evt->event.fd, ZSOCK_SOL_SOCKET, ZSOCK_SO_ERROR, &sock_error,
+				       &optlen);
 		LOG_ERR("Websocket socket %d error (%d)", evt->event.fd, sock_error);
 
 		if (evt->event.fd == ws->fds[0].fd) {
@@ -232,8 +230,8 @@ static int console_ws_http_cb(int ws_socket, struct http_request_ctx *request_ct
 	ctx->fds[0].events = ZSOCK_POLLIN;
 	ctx->new_client = true;
 
-	ret = net_socket_service_register(&host_console_ws_server, ctx->fds,
-					  ARRAY_SIZE(ctx->fds), ctx);
+	ret = net_socket_service_register(&host_console_ws_server, ctx->fds, ARRAY_SIZE(ctx->fds),
+					  ctx);
 	if (ret < 0) {
 		LOG_ERR("Failed to register socket service, %d", ret);
 		goto error;
@@ -262,22 +260,23 @@ error:
 static uint8_t ws_recv_buf_console_service[256];
 
 struct http_resource_detail_websocket ws_res_detail_console_service = {
-	.common = {
-		.type = HTTP_RESOURCE_TYPE_WEBSOCKET,
+	.common =
+		{
+			.type = HTTP_RESOURCE_TYPE_WEBSOCKET,
 
-		/* We need HTTP/1.1 GET method for upgrading */
-		.bitmask_of_supported_http_methods = BIT(HTTP_GET),
-	},
+			/* We need HTTP/1.1 GET method for upgrading */
+			.bitmask_of_supported_http_methods = BIT(HTTP_GET),
+		},
 	.cb = console_ws_http_cb,
 	.data_buffer = ws_recv_buf_console_service,
 	.data_buffer_len = sizeof(ws_recv_buf_console_service),
 	.user_data = &host_websocket,
 };
-HTTP_RESOURCE_DEFINE(host_console_ws_http, http_service,
-		     "/console/host", &ws_res_detail_console_service);
+HTTP_RESOURCE_DEFINE(host_console_ws_http, http_service, "/console/host",
+		     &ws_res_detail_console_service);
 #if defined(CONFIG_APP_HTTPS)
-HTTP_RESOURCE_DEFINE(host_console_ws_https, https_service,
-		     "/console/host", &ws_res_detail_console_service);
+HTTP_RESOURCE_DEFINE(host_console_ws_https, https_service, "/console/host",
+		     &ws_res_detail_console_service);
 #endif
 
 int console_bridge_ws_init(void)
@@ -287,11 +286,9 @@ int console_bridge_ws_init(void)
 	memset(&host_websocket, 0, sizeof(host_websocket));
 	host_websocket.fds[0].fd = -1;
 
-	k_thread_create(&socket_send_thread_data, socket_send_thread_stack_area,
-			STACK_SIZE,
-			socket_send_thread,
-			NULL, NULL, NULL,
-			CONFIG_CONSOLE_BRIDGE_WS_PRIORITY, 0, K_NO_WAIT);
+	k_thread_create(&socket_send_thread_data, socket_send_thread_stack_area, STACK_SIZE,
+			socket_send_thread, NULL, NULL, NULL, CONFIG_CONSOLE_BRIDGE_WS_PRIORITY, 0,
+			K_NO_WAIT);
 
 	k_thread_name_set(&socket_send_thread_data, "websocket_send");
 

--- a/src/console_logger.c
+++ b/src/console_logger.c
@@ -8,15 +8,15 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(console_logger, LOG_LEVEL_INF);
 
-#include <zephyr/spinlock.h>
-#include <zephyr/posix/fcntl.h>
-#include <zephyr/drivers/uart.h>
-#include <zephyr/drivers/gpio.h>
-#include <zephyr/net/socket.h>
 #include <errno.h>
-#include <unistd.h>
-#include <sys/socket.h>
 #include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/posix/fcntl.h>
+#include <zephyr/spinlock.h>
 
 #include "synch.h"
 
@@ -30,7 +30,8 @@ BUILD_ASSERT(DT_NODE_EXISTS(UART_NODE), "host-console-uart node missing");
 /* UART mux select GPIO from device tree */
 #define UARTMUXSEL_NODE DT_ALIAS(host_console_uart_muxsel)
 #if DT_NODE_EXISTS(UARTMUXSEL_NODE)
-static const struct gpio_dt_spec host_console_uart_muxsel_gpio = GPIO_DT_SPEC_GET(UARTMUXSEL_NODE, gpios);
+static const struct gpio_dt_spec host_console_uart_muxsel_gpio =
+	GPIO_DT_SPEC_GET(UARTMUXSEL_NODE, gpios);
 #endif
 
 /*

--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -10,18 +10,18 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(wallabmc_dhcp, LOG_LEVEL_INF);
 
-#include <zephyr/kernel.h>
-#include <zephyr/linker/sections.h>
 #include <errno.h>
 #include <stdio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/linker/sections.h>
 
-#include <zephyr/net/net_if.h>
-#include <zephyr/net/net_core.h>
 #include <zephyr/net/net_context.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_if.h>
 #include <zephyr/net/net_mgmt.h>
 
-#include "dhcp.h"
 #include "config.h"
+#include "dhcp.h"
 
 #define DHCP_OPTION_NTP (42)
 
@@ -35,8 +35,7 @@ static void start_dhcpv4_client(struct net_if *iface, void *user_data)
 {
 	ARG_UNUSED(user_data);
 
-	LOG_INF("Start on %s[%d]", net_if_get_device(iface)->name,
-		net_if_get_by_iface(iface));
+	LOG_INF("Start on %s[%d]", net_if_get_device(iface)->name, net_if_get_by_iface(iface));
 	net_dhcpv4_start(iface);
 }
 
@@ -44,8 +43,7 @@ static void restart_dhcpv4_client(struct net_if *iface, void *user_data)
 {
 	ARG_UNUSED(user_data);
 
-	LOG_INF("Restart on %s[%d]", net_if_get_device(iface)->name,
-		net_if_get_by_iface(iface));
+	LOG_INF("Restart on %s[%d]", net_if_get_device(iface)->name, net_if_get_by_iface(iface));
 	net_dhcpv4_restart(iface);
 }
 
@@ -53,14 +51,11 @@ static void stop_dhcpv4_client(struct net_if *iface, void *user_data)
 {
 	ARG_UNUSED(user_data);
 
-	LOG_INF("Stop on %s[%d]", net_if_get_device(iface)->name,
-		net_if_get_by_iface(iface));
+	LOG_INF("Stop on %s[%d]", net_if_get_device(iface)->name, net_if_get_by_iface(iface));
 	net_dhcpv4_stop(iface);
 }
 
-static void handler(struct net_mgmt_event_callback *cb,
-		    uint64_t mgmt_event,
-		    struct net_if *iface)
+static void handler(struct net_mgmt_event_callback *cb, uint64_t mgmt_event, struct net_if *iface)
 {
 	int i = 0;
 
@@ -71,31 +66,27 @@ static void handler(struct net_mgmt_event_callback *cb,
 	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
 		char buf[NET_IPV4_ADDR_LEN];
 
-		if (iface->config.ip.ipv4->unicast[i].ipv4.addr_type !=
-							NET_ADDR_DHCP) {
+		if (iface->config.ip.ipv4->unicast[i].ipv4.addr_type != NET_ADDR_DHCP) {
 			continue;
 		}
 
 		LOG_INF("New lease on %s[%d]", net_if_get_device(iface)->name,
-						net_if_get_by_iface(iface));
-		LOG_INF("    Address: %s", net_addr_ntop(AF_INET,
-				&iface->config.ip.ipv4->unicast[i].ipv4.address.in_addr,
-					buf, sizeof(buf)));
-		LOG_DBG("    Subnet: %s", net_addr_ntop(AF_INET,
-					&iface->config.ip.ipv4->unicast[i].netmask,
-					buf, sizeof(buf)));
-		LOG_DBG("    Router: %s", net_addr_ntop(AF_INET,
-					&iface->config.ip.ipv4->gw,
-					buf, sizeof(buf)));
-		LOG_DBG("    Lease time: %u seconds",
-					iface->config.dhcpv4.lease_time);
+			net_if_get_by_iface(iface));
+		LOG_INF("    Address: %s",
+			net_addr_ntop(AF_INET,
+				      &iface->config.ip.ipv4->unicast[i].ipv4.address.in_addr, buf,
+				      sizeof(buf)));
+		LOG_DBG("    Subnet: %s",
+			net_addr_ntop(AF_INET, &iface->config.ip.ipv4->unicast[i].netmask, buf,
+				      sizeof(buf)));
+		LOG_DBG("    Router: %s",
+			net_addr_ntop(AF_INET, &iface->config.ip.ipv4->gw, buf, sizeof(buf)));
+		LOG_DBG("    Lease time: %u seconds", iface->config.dhcpv4.lease_time);
 	}
 }
 
-static void option_handler(struct net_dhcpv4_option_callback *cb,
-			   size_t length,
-			   enum net_dhcpv4_msg_type msg_type,
-			   struct net_if *iface)
+static void option_handler(struct net_dhcpv4_option_callback *cb, size_t length,
+			   enum net_dhcpv4_msg_type msg_type, struct net_if *iface)
 {
 	char buf[NET_IPV4_ADDR_LEN];
 
@@ -105,12 +96,10 @@ static void option_handler(struct net_dhcpv4_option_callback *cb,
 
 int dhcp4_init(void)
 {
-	net_mgmt_init_event_callback(&mgmt_cb, handler,
-				     NET_EVENT_IPV4_ADDR_ADD);
+	net_mgmt_init_event_callback(&mgmt_cb, handler, NET_EVENT_IPV4_ADDR_ADD);
 	net_mgmt_add_event_callback(&mgmt_cb);
 
-	net_dhcpv4_init_option_callback(&dhcp_cb, option_handler,
-					DHCP_OPTION_NTP, ntp_server,
+	net_dhcpv4_init_option_callback(&dhcp_cb, option_handler, DHCP_OPTION_NTP, ntp_server,
 					sizeof(ntp_server));
 
 	net_dhcpv4_add_option_callback(&dhcp_cb);

--- a/src/fs.c
+++ b/src/fs.c
@@ -6,11 +6,11 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(wallabmc_fs, LOG_LEVEL_INF);
 
-#include <zephyr/kernel.h>
-#include <zephyr/fs/fs.h>
 #include <zephyr/drivers/flash.h>
-#include <zephyr/storage/flash_map.h>
+#include <zephyr/fs/fs.h>
+#include <zephyr/kernel.h>
 #include <zephyr/kvss/nvs.h>
+#include <zephyr/storage/flash_map.h>
 
 #include "fs.h"
 
@@ -24,24 +24,21 @@ LOG_MODULE_REGISTER(wallabmc_fs, LOG_LEVEL_INF);
 #if !defined(PARTITION_EXISTS)
 /* Zephyr pre-4.4 compat */
 #define PARTITION_EXISTS FIXED_PARTITION_EXISTS
-#define PARTITION_ID FIXED_PARTITION_ID
+#define PARTITION_ID	 FIXED_PARTITION_ID
 #define PARTITION_DEVICE FIXED_PARTITION_DEVICE
 #define PARTITION_OFFSET FIXED_PARTITION_OFFSET
-#define PARTITION_SIZE FIXED_PARTITION_SIZE
+#define PARTITION_SIZE	 FIXED_PARTITION_SIZE
 #endif
 
 #if defined(CONFIG_PERSISTENT_STORAGE) && PARTITION_EXISTS(STORAGE_PARTITION_LABEL)
-#define STORAGE_PARTITION_ID		PARTITION_ID(STORAGE_PARTITION_LABEL)
-#define STORAGE_PARTITION_DEVICE	PARTITION_DEVICE(STORAGE_PARTITION_LABEL)
-#define STORAGE_PARTITION_OFFSET	PARTITION_OFFSET(STORAGE_PARTITION_LABEL)
-#define STORAGE_PARTITION_SIZE		PARTITION_SIZE(STORAGE_PARTITION_LABEL)
+#define STORAGE_PARTITION_ID	 PARTITION_ID(STORAGE_PARTITION_LABEL)
+#define STORAGE_PARTITION_DEVICE PARTITION_DEVICE(STORAGE_PARTITION_LABEL)
+#define STORAGE_PARTITION_OFFSET PARTITION_OFFSET(STORAGE_PARTITION_LABEL)
+#define STORAGE_PARTITION_SIZE	 PARTITION_SIZE(STORAGE_PARTITION_LABEL)
 
 static bool fs_is_enabled;
 
-bool fs_enabled(void)
-{
-	return fs_is_enabled;
-}
+bool fs_enabled(void) { return fs_is_enabled; }
 
 static struct nvs_fs nvs_fs = {
 	.flash_device = STORAGE_PARTITION_DEVICE,
@@ -63,8 +60,8 @@ static int mount_fs(void)
 
 	nvs_fs.sector_size = info.size;
 	nvs_fs.sector_count = STORAGE_PARTITION_SIZE / nvs_fs.sector_size;
-	LOG_INF("  NVS using flash at 0x%08lx sector size 0x%08x sector count %u",
-		nvs_fs.offset, nvs_fs.sector_size, nvs_fs.sector_count);
+	LOG_INF("  NVS using flash at 0x%08lx sector size 0x%08x sector count %u", nvs_fs.offset,
+		nvs_fs.sector_size, nvs_fs.sector_count);
 
 	/*
 	 * CONFIG_NVS_INIT_BAD_MEMORY_REGION is set, so this will try to init
@@ -177,8 +174,5 @@ int fs_init(void)
 	return 0;
 }
 
-int fs_exit(void)
-{
-	return umount_fs();
-}
+int fs_exit(void) { return umount_fs(); }
 #endif /* defined(CONFIG_PERSISTENT_STORAGE) && PARTITION_EXISTS(STORAGE_PARTITION_LABEL) */

--- a/src/fs.h
+++ b/src/fs.h
@@ -8,7 +8,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/storage/flash_map.h>
 
-#define STORAGE_PARTITION_LABEL		storage_partition
+#define STORAGE_PARTITION_LABEL storage_partition
 #if defined(CONFIG_PERSISTENT_STORAGE) && FIXED_PARTITION_EXISTS(STORAGE_PARTITION_LABEL)
 int fs_init(void);
 int fs_exit(void);
@@ -18,35 +18,17 @@ ssize_t fs_key_write(uint16_t id, const void *buf, size_t size);
 int fs_clear(void);
 
 #else /* defined(CONFIG_PERSISTENT_STORAGE) && FIXED_PARTITION_EXISTS(STORAGE_PARTITION_LABEL) */
-static inline int fs_init(void)
-{
-	return 0;
-}
+static inline int fs_init(void) { return 0; }
 
-static inline int fs_exit(void)
-{
-	return 0;
-}
+static inline int fs_exit(void) { return 0; }
 
-static inline bool fs_enabled(void)
-{
-	return false;
-}
+static inline bool fs_enabled(void) { return false; }
 
-static inline ssize_t fs_key_read(uint16_t id, void *buf, size_t size)
-{
-	return -ENODEV;
-}
+static inline ssize_t fs_key_read(uint16_t id, void *buf, size_t size) { return -ENODEV; }
 
-static inline ssize_t fs_key_write(uint16_t id, const void *buf, size_t size)
-{
-	return -ENODEV;
-}
+static inline ssize_t fs_key_write(uint16_t id, const void *buf, size_t size) { return -ENODEV; }
 
-static inline int fs_clear(void)
-{
-	return 0;
-}
+static inline int fs_clear(void) { return 0; }
 
 #endif /* defined(CONFIG_PERSISTENT_STORAGE) && FIXED_PARTITION_EXISTS(STORAGE_PARTITION_LABEL) */
 

--- a/src/http.c
+++ b/src/http.c
@@ -9,9 +9,9 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/net/tls_credentials.h>
 #include <zephyr/net/http/server.h>
 #include <zephyr/net/http/service.h>
+#include <zephyr/net/tls_credentials.h>
 #if defined(CONFIG_SHELL_BACKEND_WEBSOCKET)
 #include <zephyr/shell/shell_websocket.h>
 #endif
@@ -20,12 +20,11 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(wallabmc_http, LOG_LEVEL_INF);
 
-#include "http.h"
 #include "config.h"
+#include "http.h"
 
 static uint16_t http_service_port = 80;
-HTTP_SERVICE_DEFINE(http_service, NULL, &http_service_port,
-		    3, 10, NULL, NULL, NULL);
+HTTP_SERVICE_DEFINE(http_service, NULL, &http_service_port, 3, 10, NULL, NULL, NULL);
 
 #if defined(CONFIG_SHELL_BACKEND_WEBSOCKET)
 DEFINE_WEBSOCKET_SERVICE(http_service);
@@ -47,27 +46,26 @@ DEFINE_WEBSOCKET_SERVICE(http_service);
 
 enum tls_tag {
 #if defined(CONFIG_APP_HTTPS_PUBLIC_KEY)
-        /** Used for both the public and private server keys */
-        HTTP_SERVER_CERTIFICATE_TAG,
+	/** Used for both the public and private server keys */
+	HTTP_SERVER_CERTIFICATE_TAG,
 #endif
 #if defined(CONFIG_APP_HTTPS_PSK)
-        PSK_TAG,
+	PSK_TAG,
 #endif
 };
 
 static const sec_tag_t sec_tag_list_verify_none[] = {
 #if defined(CONFIG_APP_HTTPS_PUBLIC_KEY)
-		HTTP_SERVER_CERTIFICATE_TAG,
+	HTTP_SERVER_CERTIFICATE_TAG,
 #endif
 #if defined(CONFIG_APP_HTTPS_PSK)
-		PSK_TAG,
+	PSK_TAG,
 #endif
-	};
+};
 
 static uint16_t https_service_port = 443;
-HTTPS_SERVICE_DEFINE(https_service, NULL, &https_service_port,
-		     3, 10, NULL, NULL, NULL, sec_tag_list_verify_none,
-		     sizeof(sec_tag_list_verify_none));
+HTTPS_SERVICE_DEFINE(https_service, NULL, &https_service_port, 3, 10, NULL, NULL, NULL,
+		     sec_tag_list_verify_none, sizeof(sec_tag_list_verify_none));
 
 #if defined(CONFIG_SHELL_BACKEND_WEBSOCKET)
 DEFINE_WEBSOCKET_SERVICE(https_service);
@@ -78,17 +76,14 @@ static int setup_tls(void)
 	int err = 0;
 
 #if defined(CONFIG_APP_HTTPS_PUBLIC_KEY)
-	err = tls_credential_add(HTTP_SERVER_CERTIFICATE_TAG,
-				 TLS_CREDENTIAL_PUBLIC_CERTIFICATE,
-				 server_certificate,
-				 sizeof(server_certificate));
+	err = tls_credential_add(HTTP_SERVER_CERTIFICATE_TAG, TLS_CREDENTIAL_PUBLIC_CERTIFICATE,
+				 server_certificate, sizeof(server_certificate));
 	if (err < 0) {
 		LOG_ERR("Failed to register public certificate: %d", err);
 		return err;
 	}
 
-	err = tls_credential_add(HTTP_SERVER_CERTIFICATE_TAG,
-				 TLS_CREDENTIAL_PRIVATE_KEY,
+	err = tls_credential_add(HTTP_SERVER_CERTIFICATE_TAG, TLS_CREDENTIAL_PRIVATE_KEY,
 				 private_key, sizeof(private_key));
 	if (err < 0) {
 		LOG_ERR("Failed to register private key: %d", err);
@@ -100,19 +95,14 @@ static int setup_tls(void)
 	const char *psk;
 	int psk_len;
 	if (config_bmc_https_psk(&psk, &psk_len)) {
-		err = tls_credential_add(PSK_TAG,
-					 TLS_CREDENTIAL_PSK,
-					 psk,
-					 psk_len);
+		err = tls_credential_add(PSK_TAG, TLS_CREDENTIAL_PSK, psk, psk_len);
 		if (err < 0) {
 			LOG_ERR("Failed to register PSK: %d", err);
 			return err;
 		}
 
 		static const char psk_id[] = "WallaBMC";
-		err = tls_credential_add(PSK_TAG,
-					 TLS_CREDENTIAL_PSK_ID,
-					 psk_id,
+		err = tls_credential_add(PSK_TAG, TLS_CREDENTIAL_PSK_ID, psk_id,
 					 sizeof(psk_id) - 1);
 		if (err < 0) {
 			LOG_ERR("Failed to register PSK ID: %d", err);
@@ -123,11 +113,8 @@ static int setup_tls(void)
 
 	return err;
 }
-#else /* defined(CONFIG_APP_HTTPS) */
-static int setup_tls(void)
-{
-	return 0;
-}
+#else  /* defined(CONFIG_APP_HTTPS) */
+static int setup_tls(void) { return 0; }
 #endif /* defined(CONFIG_APP_HTTPS) */
 
 #include <zephyr/net/websocket.h>
@@ -141,8 +128,8 @@ int ws_validate_auth(int ws_socket, struct http_request_ctx *request_ctx, void *
 	int rc;
 	int32_t timeout_ms = 3000;
 
-	rc = websocket_recv_msg(ws_socket, rx_buf, sizeof(rx_buf) - 1,
-				&message_type, &remaining, timeout_ms);
+	rc = websocket_recv_msg(ws_socket, rx_buf, sizeof(rx_buf) - 1, &message_type, &remaining,
+				timeout_ms);
 	if (rc <= 0) {
 		LOG_WRN("No websocket auth message (err=%d)", rc);
 		websocket_disconnect(ws_socket);
@@ -171,8 +158,10 @@ int ws_validate_auth(int ws_socket, struct http_request_ctx *request_ctx, void *
 	return 0;
 }
 
-static int (*shell_http_ws_cb)(int ws_socket, struct http_request_ctx *request_ctx, void *user_data);
-static int (*shell_https_ws_cb)(int ws_socket, struct http_request_ctx *request_ctx, void *user_data);
+static int (*shell_http_ws_cb)(int ws_socket, struct http_request_ctx *request_ctx,
+			       void *user_data);
+static int (*shell_https_ws_cb)(int ws_socket, struct http_request_ctx *request_ctx,
+				void *user_data);
 
 int shell_http_ws_auth_cb(int ws_socket, struct http_request_ctx *request_ctx, void *user_data)
 {

--- a/src/http.h
+++ b/src/http.h
@@ -12,7 +12,11 @@ int ws_validate_auth(int ws_socket, struct http_request_ctx *request_ctx, void *
 #else
 struct http_request_ctx;
 static inline int app_http_server_init(void) { return 0; }
-static inline int ws_validate_auth(int ws_socket, struct http_request_ctx *request_ctx, void *user_data) { return -EACCES; }
+static inline int ws_validate_auth(int ws_socket, struct http_request_ctx *request_ctx,
+				   void *user_data)
+{
+	return -EACCES;
+}
 #endif
 
 #endif

--- a/src/jtag.c
+++ b/src/jtag.c
@@ -7,24 +7,24 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(wallabmc_jtag, LOG_LEVEL_INF);
 
-#include <zephyr/posix/fcntl.h>
+#include <errno.h>
+#include <sys/socket.h>
+#include <unistd.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/net/socket.h>
-#include <errno.h>
-#include <unistd.h>
-#include <sys/socket.h>
+#include <zephyr/posix/fcntl.h>
 
-#define JTAG_PORT 7777
+#define JTAG_PORT	       7777
 #define JTAG_DAEMON_STACK_SIZE K_THREAD_STACK_SIZEOF(jtag_stack_area)
 #define JTAG_DAEMON_PRIORITY   CONFIG_JTAG_DAEMON_PRIORITY
 
 K_THREAD_STACK_DEFINE(jtag_stack_area, CONFIG_JTAG_DAEMON_STACK_SIZE);
 static struct k_thread jtag_thread_data;
 
-#define JTAG_TCK_NODE  DT_ALIAS(jtagtck)
-#define JTAG_TMS_NODE  DT_ALIAS(jtagtms)
-#define JTAG_TDI_NODE  DT_ALIAS(jtagtdi)
-#define JTAG_TDO_NODE  DT_ALIAS(jtagtdo)
+#define JTAG_TCK_NODE DT_ALIAS(jtagtck)
+#define JTAG_TMS_NODE DT_ALIAS(jtagtms)
+#define JTAG_TDI_NODE DT_ALIAS(jtagtdi)
+#define JTAG_TDO_NODE DT_ALIAS(jtagtdo)
 
 BUILD_ASSERT(DT_NODE_EXISTS(JTAG_TCK_NODE), "alias jtagtck missing");
 BUILD_ASSERT(DT_NODE_EXISTS(JTAG_TMS_NODE), "alias jtagtms missing");
@@ -63,10 +63,7 @@ static inline void set_tdi(int state)
 	}
 }
 
-static inline int get_tdo(void)
-{
-	return gpio_pin_get_dt(&tdo);
-}
+static inline int get_tdo(void) { return gpio_pin_get_dt(&tdo); }
 
 static void jtag_pins_disable(void)
 {
@@ -253,8 +250,7 @@ static void jtag_daemon_thread(void *a, void *b, void *c)
 		socklen_t client_addr_len = sizeof(client_addr);
 		int client_fd;
 
-		client_fd = accept(server_fd, (struct sockaddr *)&client_addr,
-				   &client_addr_len);
+		client_fd = accept(server_fd, (struct sockaddr *)&client_addr, &client_addr_len);
 		if (client_fd < 0) {
 			LOG_ERR("accept() failed: %d", errno);
 			continue;
@@ -275,11 +271,8 @@ int jtag_init(void)
 	LOG_INF("Starting OpenOCD JTAG Daemon...");
 
 	/* Start the JTAG daemon thread */
-	k_thread_create(&jtag_thread_data, jtag_stack_area,
-			JTAG_DAEMON_STACK_SIZE,
-			jtag_daemon_thread,
-			NULL, NULL, NULL,
-			JTAG_DAEMON_PRIORITY, 0, K_NO_WAIT);
+	k_thread_create(&jtag_thread_data, jtag_stack_area, JTAG_DAEMON_STACK_SIZE,
+			jtag_daemon_thread, NULL, NULL, NULL, JTAG_DAEMON_PRIORITY, 0, K_NO_WAIT);
 
 	k_thread_name_set(&jtag_thread_data, "jtag_daemon");
 

--- a/src/main.c
+++ b/src/main.c
@@ -8,31 +8,28 @@
 LOG_MODULE_REGISTER(wallabmc, LOG_LEVEL_INF);
 
 #include <zephyr/kernel.h>
-#include <zephyr/sys/reboot.h>
-#include <zephyr/sys/poweroff.h>
 #include <zephyr/shell/shell.h>
+#include <zephyr/sys/poweroff.h>
+#include <zephyr/sys/reboot.h>
 
-#include "fs.h"
-#include "config.h"
 #include "button.h"
-#include "net.h"
+#include "config.h"
+#include "console_bridge.h"
+#include "console_bridge_ws.h"
+#include "console_logger.h"
+#include "fs.h"
+#include "git_sha.h"
 #include "http.h"
+#include "jtag.h"
+#include "net.h"
 #include "power.h"
 #include "rtc.h"
 #include "sensors.h"
-#include "jtag.h"
-#include "console_logger.h"
-#include "console_bridge.h"
-#include "console_bridge_ws.h"
 #include "vpd.h"
-#include "git_sha.h"
 
 static bool boot_finished = false;
 
-bool is_boot_finished(void)
-{
-	return boot_finished;
-}
+bool is_boot_finished(void) { return boot_finished; }
 
 static void print_banner(void)
 {
@@ -53,12 +50,9 @@ static void print_banner(void)
 	LOG_INF("Zephyr OS build: %s", BANNER_VERSION);
 #if defined(CONFIG_REDFISH)
 	LOG_INF("Board: %s", CONFIG_REDFISH_SYSTEM_PRODUCT_NAME);
-	LOG_INF("System: %s %s (CPU: %s x%d, Memory: %d GiB)",
-		CONFIG_REDFISH_SYSTEM_MANUFACTURER,
-		CONFIG_REDFISH_SYSTEM_MODEL,
-		CONFIG_REDFISH_SYSTEM_PROCESSOR_MODEL,
-		CONFIG_REDFISH_SYSTEM_PROCESSOR_COUNT,
-		CONFIG_REDFISH_SYSTEM_MEMORY_GIB);
+	LOG_INF("System: %s %s (CPU: %s x%d, Memory: %d GiB)", CONFIG_REDFISH_SYSTEM_MANUFACTURER,
+		CONFIG_REDFISH_SYSTEM_MODEL, CONFIG_REDFISH_SYSTEM_PROCESSOR_MODEL,
+		CONFIG_REDFISH_SYSTEM_PROCESSOR_COUNT, CONFIG_REDFISH_SYSTEM_MEMORY_GIB);
 #endif
 }
 
@@ -79,7 +73,8 @@ FUNC_NORETURN int bmc_reboot(void)
 	sys_reboot(SYS_REBOOT_WARM);
 	sys_reboot(SYS_REBOOT_COLD);
 	k_panic();
-	for (;;);
+	for (;;)
+		;
 }
 
 static FUNC_NORETURN int bmc_poweroff(void)
@@ -95,7 +90,8 @@ static FUNC_NORETURN int bmc_poweroff(void)
 	sys_poweroff();
 	k_panic();
 #endif
-	for (;;);
+	for (;;)
+		;
 }
 
 static int cmd_bmc_reboot(const struct shell *sh, size_t argc, char **argv)
@@ -114,11 +110,9 @@ static int cmd_bmc_poweroff(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_bmc_cmds,
-	SHELL_CMD(reboot,	NULL, "Reboot BMC.", cmd_bmc_reboot),
-	SHELL_CMD(poweroff,	NULL, "Power off BMC.", cmd_bmc_poweroff),
-	SHELL_SUBCMD_SET_END
-);
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_bmc_cmds, SHELL_CMD(reboot, NULL, "Reboot BMC.", cmd_bmc_reboot),
+			       SHELL_CMD(poweroff, NULL, "Power off BMC.", cmd_bmc_poweroff),
+			       SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(bmc, &sub_bmc_cmds, "BMC system commands", NULL);
 
@@ -128,33 +122,29 @@ static int cmd_hop(const struct shell *sh, size_t argc, char **argv)
 	ARG_UNUSED(argv);
 
 	/* Wallaby on ground */
-	const char *wallaby_ground[] = {
-		"",
-		"",
-		"",
-		"             /)",
-		"          <.' \\_",
-		"            / ( )\\",
-		"            __|/  \\__",
-		NULL
-	};
+	const char *wallaby_ground[] = {"",
+					"",
+					"",
+					"             /)",
+					"          <.' \\_",
+					"            / ( )\\",
+					"            __|/  \\__",
+					NULL};
 
 	/* Wallaby in air (hopped up) */
-	const char *wallaby_air[] = {
-		"             /)",
-		"          <.' \\_",
-		"            / ( )\\",
-		"            |/  \\",
-		"            /     \\",
-		"",
-		"",
-		NULL
-	};
+	const char *wallaby_air[] = {"             /)",
+				     "          <.' \\_",
+				     "            / ( )\\",
+				     "            |/  \\",
+				     "            /     \\",
+				     "",
+				     "",
+				     NULL};
 
-	int pos;  /* Horizontal position */
+	int pos; /* Horizontal position */
 	int i, j;
-	int max_pos = 60;  /* Maximum horizontal position */
-	int num_hops = 4;  /* Number of complete hops */
+	int max_pos = 60; /* Maximum horizontal position */
+	int num_hops = 4; /* Number of complete hops */
 	bool in_air = false;
 
 	shell_print(sh, "\n");
@@ -176,11 +166,13 @@ static int cmd_hop(const struct shell *sh, size_t argc, char **argv)
 
 			/* Print the frame with horizontal offset */
 			for (j = 0; current_frame[j] != NULL; j++) {
-					shell_print(sh, "%*s%s", pos, "", current_frame[j]);
+				shell_print(sh, "%*s%s", pos, "", current_frame[j]);
 			}
-			shell_print(sh, "----------------------------------------------------------------------------------");
+			shell_print(
+				sh,
+				"----------------------------------------------------------------------------------");
 
-			k_msleep(120);  /* Animation speed */
+			k_msleep(120); /* Animation speed */
 		}
 	}
 

--- a/src/net.c
+++ b/src/net.c
@@ -7,21 +7,21 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(wallabmc_net, LOG_LEVEL_INF);
 
-#include <zephyr/kernel.h>
-#include <zephyr/linker/sections.h>
 #include <errno.h>
 #include <stdio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/linker/sections.h>
 
-#include <zephyr/net/net_config.h>
-#include <zephyr/net/net_if.h>
-#include <zephyr/net/net_core.h>
-#include <zephyr/net/net_context.h>
-#include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/dns_resolve.h>
+#include <zephyr/net/net_config.h>
+#include <zephyr/net/net_context.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_mgmt.h>
 
-#include "net.h"
-#include "dhcp.h"
 #include "config.h"
+#include "dhcp.h"
+#include "net.h"
 #include "ntp.h"
 
 int net_do_set_hostname(const char *hostname)
@@ -111,10 +111,7 @@ int net_do_set_default_ip4_from_config(void)
 	return rc;
 }
 
-int net_start_dhcp4(void)
-{
-	return start_dhcp4();
-}
+int net_start_dhcp4(void) { return start_dhcp4(); }
 
 int net_stop_dhcp4(void)
 {
@@ -129,9 +126,9 @@ int net_stop_dhcp4(void)
 		LOG_ERR("Cannot reset IPv4 address (err=%d)", rc);
 
 #ifdef CONFIG_APP_DNS_RESOLVE
-	static const char *dns_servers[] = { CONFIG_DNS_SERVER1, NULL };
-	rc = dns_resolve_reconfigure(dns_resolve_get_default(), dns_servers,
-					NULL, DNS_SOURCE_MANUAL);
+	static const char *dns_servers[] = {CONFIG_DNS_SERVER1, NULL};
+	rc = dns_resolve_reconfigure(dns_resolve_get_default(), dns_servers, NULL,
+				     DNS_SOURCE_MANUAL);
 	if (rc)
 		LOG_ERR("Cannot reset DNS resolver (err=%d)", rc);
 #endif

--- a/src/ntp.c
+++ b/src/ntp.c
@@ -10,15 +10,15 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(wallabmc_ntp, LOG_LEVEL_DBG);
 
-#include <zephyr/net/socket.h>
-#include <zephyr/net/socket_service.h>
-#include <zephyr/net/sntp.h>
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <zephyr/net/sntp.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/socket_service.h>
 
+#include "config.h"
 #include "ntp.h"
 #include "rtc.h"
-#include "config.h"
 
 static int sntp_set_clocks(struct sntp_time *ts)
 {
@@ -45,7 +45,7 @@ static int sntp_set_clocks(struct sntp_time *ts)
 }
 
 static int dns_query(const char *host, uint16_t port, int family, int socktype,
-			struct sockaddr *addr, socklen_t *addrlen)
+		     struct sockaddr *addr, socklen_t *addrlen)
 {
 	struct addrinfo hints = {
 		.ai_family = family,
@@ -70,7 +70,7 @@ static int dns_query(const char *host, uint16_t port, int family, int socktype,
 	return 0;
 }
 
-#define NTP_TIMEOUT_MS 3000
+#define NTP_TIMEOUT_MS	3000
 #define NTP_SERVER_ADDR "pool.ntp.org"
 #define NTP_SERVER_PORT 123
 
@@ -131,7 +131,7 @@ static void ntp_sync_work_handler(struct k_work *work)
 		if (!ntp_synced) {
 			ntp_synced = true;
 			/* Upgrade to 6 hour resync */
-			ntp_interval_sec = 6*60*60;
+			ntp_interval_sec = 6 * 60 * 60;
 		}
 	}
 
@@ -144,10 +144,7 @@ static void ntp_sync_work_handler(struct k_work *work)
 	k_work_schedule(&ntp_sync_work, K_SECONDS(ntp_interval_sec));
 }
 
-bool ntp_is_synced(void)
-{
-	return ntp_synced;
-}
+bool ntp_is_synced(void) { return ntp_synced; }
 
 int start_ntp(void)
 {

--- a/src/power.c
+++ b/src/power.c
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/shell/shell.h>
-#include <stdlib.h>
 #include <ctype.h>
-#include <zephyr/sys/util.h>
-#include <zephyr/kernel.h>
+#include <stdlib.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/sys/util.h>
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 #include <zephyr/logging/log.h>
@@ -18,8 +18,8 @@ LOG_MODULE_REGISTER(wallabmc_power);
 
 #define GPIO_POWER_1 DT_ALIAS(power_gpio_1)
 #define GPIO_POWER_2 DT_ALIAS(power_gpio_2)
-#define GPIO_RESET DT_ALIAS(reset_gpio_1)
-#define STATUS_LED DT_ALIAS(status_led)
+#define GPIO_RESET   DT_ALIAS(reset_gpio_1)
+#define STATUS_LED   DT_ALIAS(status_led)
 
 static const struct gpio_dt_spec power_gpios[] = {
 #if DT_NODE_HAS_STATUS_OKAY(GPIO_POWER_1)
@@ -32,10 +32,7 @@ static const struct gpio_dt_spec power_gpios[] = {
 
 static bool system_power_state = false;
 
-bool power_get_state(void)
-{
-	return system_power_state;
-}
+bool power_get_state(void) { return system_power_state; }
 
 static int power_on(void)
 {
@@ -126,11 +123,9 @@ static int cmd_power_off(const struct shell *sh, size_t argc, char **argv)
 	return power_off();
 }
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_power_cmds,
-	SHELL_CMD(on,    NULL, "Power on.", cmd_power_on),
-	SHELL_CMD(off,   NULL, "Power off.", cmd_power_off),
-	SHELL_SUBCMD_SET_END
-);
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_power_cmds, SHELL_CMD(on, NULL, "Power on.", cmd_power_on),
+			       SHELL_CMD(off, NULL, "Power off.", cmd_power_off),
+			       SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(power, &sub_power_cmds, "Power commands", NULL);
 
@@ -138,7 +133,7 @@ static const struct gpio_dt_spec gpio_reset =
 #if DT_NODE_HAS_STATUS_OKAY(GPIO_RESET)
 	GPIO_DT_SPEC_GET(GPIO_RESET, gpios);
 #else
-	{ 0 };
+	{0};
 #endif
 
 int reset_init(void)
@@ -208,13 +203,13 @@ SHELL_CMD_REGISTER(reset, NULL, "Reset.", cmd_reset);
 static const struct gpio_dt_spec status_led = GPIO_DT_SPEC_GET(STATUS_LED, gpios);
 
 /* LED blinking thread */
-#define LED_BLINK_STACK_SIZE 256
-#define LED_BLINK_PRIORITY   (CONFIG_NUM_PREEMPT_PRIORITIES - 1)
-#define LED_BLINK_PERIOD_DOT    250
-#define LED_BLINK_PERIOD_DASH   (3 * LED_BLINK_PERIOD_DOT)
-#define LED_BLINK_PERIOD_PAUSE  (LED_BLINK_PERIOD_DOT)
+#define LED_BLINK_STACK_SIZE	256
+#define LED_BLINK_PRIORITY	(CONFIG_NUM_PREEMPT_PRIORITIES - 1)
+#define LED_BLINK_PERIOD_DOT	250
+#define LED_BLINK_PERIOD_DASH	(3 * LED_BLINK_PERIOD_DOT)
+#define LED_BLINK_PERIOD_PAUSE	(LED_BLINK_PERIOD_DOT)
 #define LED_BLINK_PERIOD_LETTER (3 * LED_BLINK_PERIOD_DOT)
-#define LED_BLINK_PERIOD_WORD   (7 * LED_BLINK_PERIOD_DOT)
+#define LED_BLINK_PERIOD_WORD	(7 * LED_BLINK_PERIOD_DOT)
 
 static K_KERNEL_STACK_DEFINE(led_blink_stack, LED_BLINK_STACK_SIZE);
 static struct k_thread led_blink_thread_data;
@@ -281,17 +276,12 @@ int status_led_init(void)
 	}
 
 	k_thread_create(&led_blink_thread_data, led_blink_stack,
-			K_THREAD_STACK_SIZEOF(led_blink_stack),
-			led_blink_thread,
-			NULL, NULL, NULL,
+			K_THREAD_STACK_SIZEOF(led_blink_stack), led_blink_thread, NULL, NULL, NULL,
 			LED_BLINK_PRIORITY, 0, K_NO_WAIT);
 	k_thread_name_set(&led_blink_thread_data, "led_blink");
 
 	return 0;
 }
-#else /* DT_NODE_HAS_STATUS_OKAY(STATUS_LED) */
-int status_led_init(void)
-{
-	return 0;
-}
+#else  /* DT_NODE_HAS_STATUS_OKAY(STATUS_LED) */
+int status_led_init(void) { return 0; }
 #endif /* DT_NODE_HAS_STATUS_OKAY(STATUS_LED) */

--- a/src/redfish.c
+++ b/src/redfish.c
@@ -11,25 +11,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/kernel.h>
-#include <zephyr/net/net_ip.h>
-#include <zephyr/net/http/server.h>
-#include <zephyr/net/http/service.h>
-#include <zephyr/net/tls_credentials.h>
-#include <zephyr/data/json.h>
-#include <zephyr/drivers/gpio.h>
-#include <zephyr/logging/log.h>
-#include <zephyr/sys/base64.h>
-#include <time.h>
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
+#include <zephyr/data/json.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net/http/server.h>
+#include <zephyr/net/http/service.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/tls_credentials.h>
+#include <zephyr/sys/base64.h>
 
 #include "config.h"
+#include "git_sha.h"
 #include "power.h"
 #include "rtc.h"
 #include "sensors.h"
 #include "vpd.h"
-#include "git_sha.h"
 
 LOG_MODULE_REGISTER(redfish_app, CONFIG_LOG_DEFAULT_LEVEL);
 
@@ -72,8 +72,8 @@ static int validate_auth(struct http_client_ctx *client)
 	uint8_t decoded_buf[CREDENTIALS_MAX_LEN];
 	size_t decoded_len = 0;
 
-	int ret = base64_decode(decoded_buf, sizeof(decoded_buf) - 1, &decoded_len,
-				b64_token, token_len);
+	int ret = base64_decode(decoded_buf, sizeof(decoded_buf) - 1, &decoded_len, b64_token,
+				token_len);
 	if (ret < 0) {
 		LOG_WRN("BASE64 decode failed");
 		return ret;
@@ -92,27 +92,26 @@ static int validate_auth(struct http_client_ctx *client)
 	return -1;
 }
 
-static int validate_and_set_headers(struct http_client_ctx *client,
-				struct http_response_ctx *ctx,
-				uint32_t supported_methods)
+static int validate_and_set_headers(struct http_client_ctx *client, struct http_response_ctx *ctx,
+				    uint32_t supported_methods)
 {
 	if (!(BIT(client->method) & supported_methods)) {
 		ctx->status = HTTP_405_METHOD_NOT_ALLOWED;
 		if (supported_methods == (BIT(HTTP_GET))) {
 			static const struct http_header headers[] = {
-				{ .name = "allow", .value = "GET" },
+				{.name = "allow", .value = "GET"},
 			};
 			ctx->headers = headers;
 			ctx->header_count = ARRAY_SIZE(headers);
 		} else if (supported_methods == (BIT(HTTP_POST))) {
 			static const struct http_header headers[] = {
-				{ .name = "allow", .value = "POST" },
+				{.name = "allow", .value = "POST"},
 			};
 			ctx->headers = headers;
 			ctx->header_count = ARRAY_SIZE(headers);
 		} else if (supported_methods == (BIT(HTTP_GET) | BIT(HTTP_PATCH))) {
 			static const struct http_header headers[] = {
-				{ .name = "allow", .value = "GET, PATCH" },
+				{.name = "allow", .value = "GET, PATCH"},
 			};
 			ctx->headers = headers;
 			ctx->header_count = ARRAY_SIZE(headers);
@@ -127,8 +126,8 @@ static int validate_and_set_headers(struct http_client_ctx *client,
 
 	if (client->method == HTTP_GET) {
 		static const struct http_header headers[] = {
-			{ .name = "content-type", .value = "application/json" },
-			{ .name = "cache-control", .value = "no-cache" },
+			{.name = "content-type", .value = "application/json"},
+			{.name = "cache-control", .value = "no-cache"},
 		};
 		ctx->headers = headers;
 		ctx->header_count = ARRAY_SIZE(headers);
@@ -141,20 +140,18 @@ static int validate_and_set_headers(struct http_client_ctx *client,
  * XXX: Zephyr could provide a send_http1_401 response to send a
  * canonical 401 header, but this still seems to work.
  */
-static void set_unauth_response(struct http_client_ctx *client,
-				struct http_response_ctx *ctx)
+static void set_unauth_response(struct http_client_ctx *client, struct http_response_ctx *ctx)
 {
 	/* XXX: should this also include allow header? */
 	static struct http_header extra_headers[] = {
-		{ .name = "www-authenticate", .value = "Basic realm=\"BMC\"" },
+		{.name = "www-authenticate", .value = "Basic realm=\"BMC\""},
 	};
 	size_t header_count = client->header_capture_ctx.count;
 	const struct http_header *headers = client->header_capture_ctx.headers;
 	bool webui = false;
 
 	for (unsigned int i = 0; i < header_count; i++) {
-		if (!strcmp(headers[i].name, "x-auth-code") &&
-		    !strcmp(headers[i].value, "webui")) {
+		if (!strcmp(headers[i].name, "x-auth-code") && !strcmp(headers[i].value, "webui")) {
 			webui = true;
 			break;
 		}
@@ -184,9 +181,9 @@ struct http_resource_user_data {
 	uint8_t *data_buffer;
 };
 
-#define USER_DATA_HEAP_SIZE		2048
-#define USER_DATA_BUFFER_GET_SIZE	1024
-#define USER_DATA_BUFFER_POST_SIZE	512
+#define USER_DATA_HEAP_SIZE	   2048
+#define USER_DATA_BUFFER_GET_SIZE  1024
+#define USER_DATA_BUFFER_POST_SIZE 512
 
 static K_HEAP_DEFINE(heap_data_buffer, USER_DATA_HEAP_SIZE);
 
@@ -209,11 +206,12 @@ static void free_user_data(struct http_resource_user_data *user_data)
 	user_data->data_buffer = NULL;
 }
 
-static bool append_user_data(struct http_resource_user_data *user_data, const void *src, size_t size)
+static bool append_user_data(struct http_resource_user_data *user_data, const void *src,
+			     size_t size)
 {
 	if (user_data->data_len + size > user_data->size) {
-		LOG_WRN("HTTP user_data buffer out of space size=%zu < %zu",
-			user_data->size, user_data->data_len + size);
+		LOG_WRN("HTTP user_data buffer out of space size=%zu < %zu", user_data->size,
+			user_data->data_len + size);
 		return false;
 	}
 
@@ -232,12 +230,10 @@ static int user_data_json_append(const char *bytes, size_t len, void *data)
 	return 0;
 }
 
-static int redfish_handler(struct http_client_ctx *client,
-			   enum http_transaction_status status,
+static int redfish_handler(struct http_client_ctx *client, enum http_transaction_status status,
 			   const struct http_request_ctx *request_ctx,
 			   struct http_response_ctx *response_ctx,
-			   struct http_resource_user_data *user_data,
-			   bool require_auth,
+			   struct http_resource_user_data *user_data, bool require_auth,
 			   int (*get_fn)(struct http_resource_user_data *user_data),
 			   int (*patch_fn)(struct http_resource_user_data *user_data),
 			   int (*post_fn)(struct http_resource_user_data *user_data))
@@ -284,7 +280,8 @@ static int redfish_handler(struct http_client_ctx *client,
 
 		/* Accumulate requests into the user_buffer, until the final request. */
 		if (request_ctx->data && request_ctx->data_len > 0) {
-			if (!append_user_data(user_data, request_ctx->data, request_ctx->data_len)) {
+			if (!append_user_data(user_data, request_ctx->data,
+					      request_ctx->data_len)) {
 				LOG_ERR("Payload too large");
 				free_user_data(user_data);
 				response_ctx->status = HTTP_400_BAD_REQUEST;
@@ -339,39 +336,35 @@ static int redfish_handler(struct http_client_ctx *client,
 }
 
 #if defined(CONFIG_APP_HTTPS)
-#define ALL_HTTP_RESOURCE_DEFINE(name, url, detail)					\
-HTTP_RESOURCE_DEFINE(name##_http, http_service, url, detail);				\
-HTTP_RESOURCE_DEFINE(name##_https, https_service, url, detail);
+#define ALL_HTTP_RESOURCE_DEFINE(name, url, detail)                                                \
+	HTTP_RESOURCE_DEFINE(name##_http, http_service, url, detail);                              \
+	HTTP_RESOURCE_DEFINE(name##_https, https_service, url, detail);
 #else
-#define ALL_HTTP_RESOURCE_DEFINE(name, url, detail)					\
-HTTP_RESOURCE_DEFINE(name##_http, http_service, url, detail);
+#define ALL_HTTP_RESOURCE_DEFINE(name, url, detail)                                                \
+	HTTP_RESOURCE_DEFINE(name##_http, http_service, url, detail);
 #endif
 
-#define REDFISH_HANDLER(name, url, require_auth, get_handler, patch_handler, post_handler) \
-/* Zephyr HTTP API serialises requests by resource so static data can be used here. */	\
-static struct http_resource_user_data name##_user_data;					\
-static int name##_handler(struct http_client_ctx *client,				\
-			  enum http_transaction_status status,				\
-			  const struct http_request_ctx *request_ctx,			\
-			  struct http_response_ctx *response_ctx,			\
-			  void *user_data)						\
-{											\
-	return redfish_handler(client, status, request_ctx, response_ctx,		\
-				user_data,						\
-				require_auth,						\
-				get_handler,						\
-				patch_handler,						\
-				post_handler);						\
-}											\
-static const struct http_resource_detail_dynamic name##_detail = {			\
-	.common = {									\
-		.type = HTTP_RESOURCE_TYPE_DYNAMIC,					\
-		.bitmask_of_supported_http_methods = -1U,				\
-	},										\
-	.cb = name##_handler,								\
-	.user_data = &name##_user_data,							\
-};											\
-ALL_HTTP_RESOURCE_DEFINE(name, url, &name##_detail);
+#define REDFISH_HANDLER(name, url, require_auth, get_handler, patch_handler, post_handler)         \
+	/* Zephyr HTTP API serialises requests by resource so static data can be used here. */     \
+	static struct http_resource_user_data name##_user_data;                                    \
+	static int name##_handler(struct http_client_ctx *client,                                  \
+				  enum http_transaction_status status,                             \
+				  const struct http_request_ctx *request_ctx,                      \
+				  struct http_response_ctx *response_ctx, void *user_data)         \
+	{                                                                                          \
+		return redfish_handler(client, status, request_ctx, response_ctx, user_data,       \
+				       require_auth, get_handler, patch_handler, post_handler);    \
+	}                                                                                          \
+	static const struct http_resource_detail_dynamic name##_detail = {                         \
+		.common =                                                                          \
+			{                                                                          \
+				.type = HTTP_RESOURCE_TYPE_DYNAMIC,                                \
+				.bitmask_of_supported_http_methods = -1U,                          \
+			},                                                                         \
+		.cb = name##_handler,                                                              \
+		.user_data = &name##_user_data,                                                    \
+	};                                                                                         \
+	ALL_HTTP_RESOURCE_DEFINE(name, url, &name##_detail);
 
 /*** Core Redfish types/containers ***/
 
@@ -380,8 +373,7 @@ struct redfish_member {
 	const char *odata_id;
 };
 static const struct json_obj_descr member_descr[] = {
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_member, "@odata.id",
-				  odata_id, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_member, "@odata.id", odata_id, JSON_TOK_STRING),
 };
 
 #define REDFISH_COLLECTION_MEMBERS_MAX 1
@@ -396,19 +388,16 @@ struct redfish_collection {
 	struct redfish_member members[REDFISH_COLLECTION_MEMBERS_MAX];
 };
 static const struct json_obj_descr collection_descr[] = {
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_collection, "@odata.id",
-				  odata_id, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_collection, "@odata.type",
-				  odata_type, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_collection, "Name",
-				  name, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_collection,
-				  "Members@odata.count", members_count,
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_collection, "@odata.id", odata_id,
+				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_collection, "@odata.type", odata_type,
+				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_collection, "Name", name, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_collection, "Members@odata.count", members_count,
 				  JSON_TOK_NUMBER),
-	JSON_OBJ_DESCR_OBJ_ARRAY_NAMED(struct redfish_collection,
-				       "Members", members,
-				       REDFISH_COLLECTION_MEMBERS_MAX, members_len,
-				       member_descr, ARRAY_SIZE(member_descr)),
+	JSON_OBJ_DESCR_OBJ_ARRAY_NAMED(struct redfish_collection, "Members", members,
+				       REDFISH_COLLECTION_MEMBERS_MAX, members_len, member_descr,
+				       ARRAY_SIZE(member_descr)),
 };
 
 /* Link (nested by others) */
@@ -416,30 +405,25 @@ struct redfish_link {
 	const char *odata_id;
 };
 static const struct json_obj_descr link_descr[] = {
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_link, "@odata.id",
-				  odata_id, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_link, "@odata.id", odata_id, JSON_TOK_STRING),
 };
-
 
 /*** /redfish/ ***/
 struct redfish_version {
 	const char *v1;
 };
 static const struct json_obj_descr version_descr[] = {
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_version, "v1",
-				  v1, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_version, "v1", v1, JSON_TOK_STRING),
 };
 
 /* GET /redfish/ */
 static int redfish_version_get_handler(struct http_resource_user_data *user_data)
 {
-	const struct redfish_version version = {
-		.v1 = "/redfish/v1/"
-	};
+	const struct redfish_version version = {.v1 = "/redfish/v1/"};
 	int ret;
 
-	ret = json_obj_encode(version_descr, ARRAY_SIZE(version_descr),
-			      &version, user_data_json_append, user_data);
+	ret = json_obj_encode(version_descr, ARRAY_SIZE(version_descr), &version,
+			      user_data_json_append, user_data);
 	if (ret < 0) {
 		LOG_ERR("Failed to encode redfish/v1/: %d", ret);
 		return HTTP_500_INTERNAL_SERVER_ERROR;
@@ -448,8 +432,7 @@ static int redfish_version_get_handler(struct http_resource_user_data *user_data
 	return 0;
 }
 
-REDFISH_HANDLER(redfish_version, "/redfish/",
-		false, /* do not require auth */
+REDFISH_HANDLER(redfish_version, "/redfish/", false, /* do not require auth */
 		redfish_version_get_handler, NULL, NULL);
 ALL_HTTP_RESOURCE_DEFINE(redfish_version_no_slash, "/redfish", &redfish_version_detail);
 
@@ -466,24 +449,19 @@ struct redfish_service_root {
 	struct redfish_link managers;
 };
 static const struct json_obj_descr service_root_descr[] = {
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_service_root, "@odata.type",
-				  odata_type, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_service_root, "@odata.id",
-				  odata_id, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_service_root, "Id",
-				  id, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_service_root, "Name",
-				  name, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_service_root, "RedfishVersion",
-				  redfish_version, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_service_root, "UUID",
-				  uuid, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_service_root, "AccountService",
-				    account_service, link_descr),
-	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_service_root, "Managers",
-				    managers, link_descr),
-	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_service_root, "Systems",
-				    systems, link_descr),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_service_root, "@odata.type", odata_type,
+				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_service_root, "@odata.id", odata_id,
+				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_service_root, "Id", id, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_service_root, "Name", name, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_service_root, "RedfishVersion", redfish_version,
+				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_service_root, "UUID", uuid, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_service_root, "AccountService", account_service,
+				    link_descr),
+	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_service_root, "Managers", managers, link_descr),
+	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_service_root, "Systems", systems, link_descr),
 };
 
 /* GET /redfish/v1/ */
@@ -496,20 +474,14 @@ static int service_root_get_handler(struct http_resource_user_data *user_data)
 		.name = "Root Service",
 		.redfish_version = "1.15.0",
 		.uuid = "92384634-2938-2342-8820-489239905423",
-		.account_service = {
-			.odata_id = "/redfish/v1/AccountService"
-		},
-		.managers = {
-			.odata_id = "/redfish/v1/Managers"
-		},
-		.systems = {
-			.odata_id = "/redfish/v1/Systems"
-		},
+		.account_service = {.odata_id = "/redfish/v1/AccountService"},
+		.managers = {.odata_id = "/redfish/v1/Managers"},
+		.systems = {.odata_id = "/redfish/v1/Systems"},
 	};
 	int ret;
 
-	ret = json_obj_encode(service_root_descr, ARRAY_SIZE(service_root_descr),
-				&service_root, user_data_json_append, user_data);
+	ret = json_obj_encode(service_root_descr, ARRAY_SIZE(service_root_descr), &service_root,
+			      user_data_json_append, user_data);
 	if (ret < 0) {
 		LOG_ERR("Failed to encode service root: %d", ret);
 		return HTTP_500_INTERNAL_SERVER_ERROR;
@@ -518,11 +490,9 @@ static int service_root_get_handler(struct http_resource_user_data *user_data)
 	return 0;
 }
 
-REDFISH_HANDLER(service_root, "/redfish/v1/",
-		false, /* do not require auth */
+REDFISH_HANDLER(service_root, "/redfish/v1/", false, /* do not require auth */
 		service_root_get_handler, NULL, NULL);
 ALL_HTTP_RESOURCE_DEFINE(service_root_no_slash, "/redfish/v1", &service_root_detail);
-
 
 /*** /redfish/v1/odata ***/
 struct redfish_odata_value {
@@ -531,12 +501,9 @@ struct redfish_odata_value {
 	const char *url;
 };
 static const struct json_obj_descr odata_value_descr[] = {
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_odata_value, "name",
-				  name, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_odata_value, "kind",
-				  kind, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_odata_value, "url",
-				  url, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_odata_value, "name", name, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_odata_value, "kind", kind, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_odata_value, "url", url, JSON_TOK_STRING),
 };
 
 #define REDFISH_ODATA_VALUES_MAX 5
@@ -547,11 +514,11 @@ struct redfish_odata {
 	struct redfish_odata_value value[REDFISH_ODATA_VALUES_MAX];
 };
 static const struct json_obj_descr odata_descr[] = {
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_odata, "@odata.context",
-				  odata_context, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_odata, "@odata.context", odata_context,
+				  JSON_TOK_STRING),
 	JSON_OBJ_DESCR_OBJ_ARRAY_NAMED(struct redfish_odata, "value", value,
-				       REDFISH_ODATA_VALUES_MAX, value_count,
-				       odata_value_descr, ARRAY_SIZE(odata_value_descr)),
+				       REDFISH_ODATA_VALUES_MAX, value_count, odata_value_descr,
+				       ARRAY_SIZE(odata_value_descr)),
 };
 
 /* GET /redfish/v1/odata */
@@ -560,18 +527,39 @@ static int odata_get_handler(struct http_resource_user_data *user_data)
 	const struct redfish_odata odata = {
 		.odata_context = "/redfish/v1/$metadata",
 		.value_count = REDFISH_ODATA_VALUES_MAX,
-		.value = {
-			{ .name = "Service", .kind = "Singleton", .url = "/redfish/v1/", },
-			{ .name = "Systems", .kind = "Singleton", .url = "/redfish/v1/Systems", },
-			{ .name = "Managers", .kind = "Singleton", .url = "/redfish/v1/Managers", },
-			{ .name = "AccountService", .kind = "Singleton", .url = "/redfish/v1/AccountService", },
-			{ .name = "Chassis", .kind = "Singleton", .url = "/redfish/v1/Chassis", },
-		},
+		.value =
+			{
+				{
+					.name = "Service",
+					.kind = "Singleton",
+					.url = "/redfish/v1/",
+				},
+				{
+					.name = "Systems",
+					.kind = "Singleton",
+					.url = "/redfish/v1/Systems",
+				},
+				{
+					.name = "Managers",
+					.kind = "Singleton",
+					.url = "/redfish/v1/Managers",
+				},
+				{
+					.name = "AccountService",
+					.kind = "Singleton",
+					.url = "/redfish/v1/AccountService",
+				},
+				{
+					.name = "Chassis",
+					.kind = "Singleton",
+					.url = "/redfish/v1/Chassis",
+				},
+			},
 	};
 	int ret;
 
-	ret = json_obj_encode(odata_descr, ARRAY_SIZE(odata_descr),
-				&odata, user_data_json_append, user_data);
+	ret = json_obj_encode(odata_descr, ARRAY_SIZE(odata_descr), &odata, user_data_json_append,
+			      user_data);
 	if (ret < 0) {
 		LOG_ERR("Failed to encode odata: %d", ret);
 		return HTTP_500_INTERNAL_SERVER_ERROR;
@@ -580,8 +568,7 @@ static int odata_get_handler(struct http_resource_user_data *user_data)
 	return 0;
 }
 
-REDFISH_HANDLER(odata, "/redfish/v1/odata",
-		false, /* do not require auth */
+REDFISH_HANDLER(odata, "/redfish/v1/odata", false, /* do not require auth */
 		odata_get_handler, NULL, NULL);
 
 /*** /redfish/v1/AccountService ***/
@@ -593,11 +580,14 @@ struct redfish_account_service {
 	struct redfish_link accounts;
 };
 static const struct json_obj_descr account_service_descr[] = {
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_account_service, "@odata.id", odata_id, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_account_service, "@odata.type", odata_type, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_account_service, "@odata.id", odata_id,
+				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_account_service, "@odata.type", odata_type,
+				  JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_account_service, "Id", id, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_account_service, "Name", name, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_account_service, "Accounts", accounts, link_descr),
+	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_account_service, "Accounts", accounts,
+				    link_descr),
 };
 
 /* GET /redfish/v1/AccountService */
@@ -608,14 +598,15 @@ static int account_service_get_handler(struct http_resource_user_data *user_data
 		.odata_type = "#AccountService.v1_10_0.AccountService",
 		.id = "AccountService",
 		.name = "Account Service",
-		.accounts = {
-			.odata_id = "/redfish/v1/AccountService/Accounts",
-		},
+		.accounts =
+			{
+				.odata_id = "/redfish/v1/AccountService/Accounts",
+			},
 	};
 	int ret;
 
 	ret = json_obj_encode(account_service_descr, ARRAY_SIZE(account_service_descr),
-				&account_service, user_data_json_append, user_data);
+			      &account_service, user_data_json_append, user_data);
 	if (ret < 0) {
 		LOG_ERR("Failed to encode account service: %d", ret);
 		return HTTP_500_INTERNAL_SERVER_ERROR;
@@ -624,8 +615,7 @@ static int account_service_get_handler(struct http_resource_user_data *user_data
 	return 0;
 }
 
-REDFISH_HANDLER(account_service, "/redfish/v1/AccountService",
-		false, /* do not require auth */
+REDFISH_HANDLER(account_service, "/redfish/v1/AccountService", false, /* do not require auth */
 		account_service_get_handler, NULL, NULL);
 
 /* GET /redfish/v1/AccountService/Accounts */
@@ -636,17 +626,18 @@ static int accounts_collection_get_handler(struct http_resource_user_data *user_
 		.odata_type = "#ManagerAccountCollection.ManagerAccountCollection",
 		.name = "Accounts Collection",
 		.members_count = 1,
-		.members = {
+		.members =
 			{
-				.odata_id = "/redfish/v1/AccountService/Accounts/1",
+				{
+					.odata_id = "/redfish/v1/AccountService/Accounts/1",
+				},
 			},
-		},
 		.members_len = 1,
 	};
 	int ret;
 
-	ret = json_obj_encode(collection_descr, ARRAY_SIZE(collection_descr),
-				&accounts_collection, user_data_json_append, user_data);
+	ret = json_obj_encode(collection_descr, ARRAY_SIZE(collection_descr), &accounts_collection,
+			      user_data_json_append, user_data);
 	if (ret < 0) {
 		LOG_ERR("Failed to encode manager: %d", ret);
 		return HTTP_500_INTERNAL_SERVER_ERROR;
@@ -655,8 +646,7 @@ static int accounts_collection_get_handler(struct http_resource_user_data *user_
 	return 0;
 }
 
-REDFISH_HANDLER(accounts_collection, "/redfish/v1/AccountService/Accounts",
-		true, /* require auth */
+REDFISH_HANDLER(accounts_collection, "/redfish/v1/AccountService/Accounts", true, /* require auth */
 		accounts_collection_get_handler, NULL, NULL);
 
 /*** /redfish/v1/AccountService/Account/1 ***/
@@ -671,7 +661,8 @@ struct redfish_account {
 };
 static const struct json_obj_descr account_descr[] = {
 	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_account, "@odata.id", odata_id, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_account, "@odata.type", odata_type, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_account, "@odata.type", odata_type,
+				  JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_account, "Id", id, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_account, "RoleId", role_id, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_account, "Name", name, JSON_TOK_STRING),
@@ -687,8 +678,8 @@ static int account_patch_handler(struct http_resource_user_data *user_data)
 	int ret;
 
 	memset(&payload, 0, sizeof(payload));
-	ret = json_obj_parse(user_data->data_buffer, user_data->data_len,
-			     account_descr, ARRAY_SIZE(account_descr), &payload);
+	ret = json_obj_parse(user_data->data_buffer, user_data->data_len, account_descr,
+			     ARRAY_SIZE(account_descr), &payload);
 	if (ret < 0) {
 		LOG_ERR("Account: Bad JSON (err=%d)", ret);
 		return HTTP_400_BAD_REQUEST;
@@ -721,8 +712,8 @@ static int account_get_handler(struct http_resource_user_data *user_data)
 	};
 	int ret;
 
-	ret = json_obj_encode(account_descr, ARRAY_SIZE(account_descr),
-				&account, user_data_json_append, user_data);
+	ret = json_obj_encode(account_descr, ARRAY_SIZE(account_descr), &account,
+			      user_data_json_append, user_data);
 	if (ret < 0) {
 		LOG_ERR("Failed to encode account: %d", ret);
 		return HTTP_500_INTERNAL_SERVER_ERROR;
@@ -731,8 +722,7 @@ static int account_get_handler(struct http_resource_user_data *user_data)
 	return 0;
 }
 
-REDFISH_HANDLER(account, "/redfish/v1/AccountService/Accounts/1",
-		true, /* require auth */
+REDFISH_HANDLER(account, "/redfish/v1/AccountService/Accounts/1", true, /* require auth */
 		account_get_handler, account_patch_handler, NULL);
 
 /*** /redfish/v1/Managers ***/
@@ -744,17 +734,12 @@ static int managers_collection_get_handler(struct http_resource_user_data *user_
 		.odata_type = "#ManagerCollection.ManagerCollection",
 		.name = "Manager Collection",
 		.members_count = 1,
-		.members = {
-			{
-				.odata_id = "/redfish/v1/Managers/bmc"
-			}
-		},
-		.members_len = 1
-	};
+		.members = {{.odata_id = "/redfish/v1/Managers/bmc"}},
+		.members_len = 1};
 	int ret;
 
-	ret = json_obj_encode(collection_descr, ARRAY_SIZE(collection_descr),
-				&managers_collection, user_data_json_append, user_data);
+	ret = json_obj_encode(collection_descr, ARRAY_SIZE(collection_descr), &managers_collection,
+			      user_data_json_append, user_data);
 	if (ret < 0) {
 		LOG_ERR("Failed to encode managers collection: %d", ret);
 		return HTTP_500_INTERNAL_SERVER_ERROR;
@@ -763,8 +748,7 @@ static int managers_collection_get_handler(struct http_resource_user_data *user_
 	return 0;
 }
 
-REDFISH_HANDLER(managers_collection, "/redfish/v1/Managers",
-		true, /* require auth */
+REDFISH_HANDLER(managers_collection, "/redfish/v1/Managers", true, /* require auth */
 		managers_collection_get_handler, NULL, NULL);
 
 /*** /redfish/v1/Managers/bmc ***/
@@ -772,16 +756,15 @@ struct redfish_manager_oem_wallabmc {
 	const char *zephyr_version;
 };
 static const struct json_obj_descr manager_oem_wallabmc_descr[] = {
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_manager_oem_wallabmc,
-				   "ZephyrVersion", zephyr_version,
-				   JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_manager_oem_wallabmc, "ZephyrVersion",
+				  zephyr_version, JSON_TOK_STRING),
 };
 struct redfish_manager_oem {
 	struct redfish_manager_oem_wallabmc wallabmc;
 };
 static const struct json_obj_descr manager_oem_descr[] = {
-	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_manager_oem, "WallaBMC",
-				     wallabmc, manager_oem_wallabmc_descr),
+	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_manager_oem, "WallaBMC", wallabmc,
+				    manager_oem_wallabmc_descr),
 };
 struct redfish_manager {
 	const char *odata_id;
@@ -796,14 +779,17 @@ struct redfish_manager {
 };
 static const struct json_obj_descr manager_descr[] = {
 	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_manager, "@odata.id", odata_id, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_manager, "@odata.type", odata_type, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_manager, "@odata.type", odata_type,
+				  JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_manager, "Id", id, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_manager, "Name", name, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_manager, "UUID", uuid, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_manager, "DateTime", date_time, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_manager, "FirmwareVersion", firmware_version, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_manager, "FirmwareVersion", firmware_version,
+				  JSON_TOK_STRING),
 	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_manager, "Oem", oem, manager_oem_descr),
-	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_manager, "EthernetInterfaces", ethernet_interfaces, link_descr),
+	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_manager, "EthernetInterfaces",
+				    ethernet_interfaces, link_descr),
 };
 
 static const char *get_iso_time(void)
@@ -825,8 +811,8 @@ static int manager_patch_handler(struct http_resource_user_data *user_data)
 	struct redfish_manager payload;
 	int ret;
 
-	ret = json_obj_parse(user_data->data_buffer, user_data->data_len,
-			     manager_descr, ARRAY_SIZE(manager_descr), &payload);
+	ret = json_obj_parse(user_data->data_buffer, user_data->data_len, manager_descr,
+			     ARRAY_SIZE(manager_descr), &payload);
 	if (ret < 0) {
 		LOG_ERR("Manager: Bad JSON (err=%d)", ret);
 		return HTTP_400_BAD_REQUEST;
@@ -854,10 +840,11 @@ static int manager_get_handler(struct http_resource_user_data *user_data)
 		.name = "WallaBMC",
 		.date_time = get_iso_time(),
 		.firmware_version = PROJECT_GIT_SHA,
-		.oem = { .wallabmc = { .zephyr_version = BANNER_VERSION } },
-		.ethernet_interfaces = {
-			.odata_id = "/redfish/v1/Managers/bmc/EthernetInterfaces",
-		},
+		.oem = {.wallabmc = {.zephyr_version = BANNER_VERSION}},
+		.ethernet_interfaces =
+			{
+				.odata_id = "/redfish/v1/Managers/bmc/EthernetInterfaces",
+			},
 	};
 	int ret;
 
@@ -866,8 +853,8 @@ static int manager_get_handler(struct http_resource_user_data *user_data)
 		LOG_ERR("Failed to get BMC UUID: %d", ret);
 	}
 
-	ret = json_obj_encode(manager_descr, ARRAY_SIZE(manager_descr),
-				&manager, user_data_json_append, user_data);
+	ret = json_obj_encode(manager_descr, ARRAY_SIZE(manager_descr), &manager,
+			      user_data_json_append, user_data);
 	if (ret < 0) {
 		LOG_ERR("Failed to encode manager: %d", ret);
 		return HTTP_500_INTERNAL_SERVER_ERROR;
@@ -876,8 +863,7 @@ static int manager_get_handler(struct http_resource_user_data *user_data)
 	return 0;
 }
 
-REDFISH_HANDLER(manager, "/redfish/v1/Managers/bmc",
-		true, /* require auth */
+REDFISH_HANDLER(manager, "/redfish/v1/Managers/bmc", true, /* require auth */
 		manager_get_handler, manager_patch_handler, NULL);
 
 /*** /redfish/v1/Managers/bmc/EthernetInterfaces ***/
@@ -889,17 +875,12 @@ static int ethernet_collection_get_handler(struct http_resource_user_data *user_
 		.odata_type = "#EthernetInterfaceCollection.EthernetInterfaceCollection",
 		.name = "Ethernet Interface Collection",
 		.members_count = 1,
-		.members = {
-			{
-				.odata_id = "/redfish/v1/Managers/bmc/EthernetInterfaces/eth0"
-			}
-		},
-		.members_len = 1
-	};
+		.members = {{.odata_id = "/redfish/v1/Managers/bmc/EthernetInterfaces/eth0"}},
+		.members_len = 1};
 	int ret;
 
-	ret = json_obj_encode(collection_descr, ARRAY_SIZE(collection_descr),
-				&ethernet_collection, user_data_json_append, user_data);
+	ret = json_obj_encode(collection_descr, ARRAY_SIZE(collection_descr), &ethernet_collection,
+			      user_data_json_append, user_data);
 	if (ret < 0) {
 		LOG_ERR("Failed to encode ethernet interfaces collection: %d", ret);
 		return HTTP_500_INTERNAL_SERVER_ERROR;
@@ -918,7 +899,8 @@ struct redfish_dhcp_v4 {
 	uint8_t dhcp_enabled;
 };
 static const struct json_obj_descr dhcp_v4_descr[] = {
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_dhcp_v4, "DHCPEnabled", dhcp_enabled, JSON_TOK_TRUE),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_dhcp_v4, "DHCPEnabled", dhcp_enabled,
+				  JSON_TOK_TRUE),
 };
 
 /* IPv4Address */
@@ -930,9 +912,11 @@ struct redfish_ipv4_addr {
 };
 static const struct json_obj_descr ipv4_addr_descr[] = {
 	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_ipv4_addr, "Address", address, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_ipv4_addr, "SubnetMask", subnet_mask, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_ipv4_addr, "SubnetMask", subnet_mask,
+				  JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_ipv4_addr, "Gateway", gateway, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_ipv4_addr, "AddressOrigin", address_origin, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_ipv4_addr, "AddressOrigin", address_origin,
+				  JSON_TOK_STRING),
 };
 
 /* EthInterface */
@@ -949,16 +933,22 @@ struct redfish_ethernet_interface {
 	size_t ipv4_static_count;
 };
 static const struct json_obj_descr ethernet_interface_descr[] = {
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_ethernet_interface, "@odata.id", odata_id, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_ethernet_interface, "@odata.type", odata_type, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_ethernet_interface, "@odata.id", odata_id,
+				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_ethernet_interface, "@odata.type", odata_type,
+				  JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_ethernet_interface, "Id", id, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_ethernet_interface, "Name", name, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_ethernet_interface, "HostName", host_name, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_ethernet_interface, "DHCPv4", dhcp_v4, dhcp_v4_descr),
-	JSON_OBJ_DESCR_OBJ_ARRAY_NAMED(struct redfish_ethernet_interface, "IPv4Addresses", ipv4_addresses,
-		       1, ipv4_count, ipv4_addr_descr, ARRAY_SIZE(ipv4_addr_descr)),
-	JSON_OBJ_DESCR_OBJ_ARRAY_NAMED(struct redfish_ethernet_interface, "IPv4StaticAddresses", ipv4_static_addresses,
-		       1, ipv4_static_count, ipv4_addr_descr, ARRAY_SIZE(ipv4_addr_descr)),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_ethernet_interface, "HostName", host_name,
+				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_ethernet_interface, "DHCPv4", dhcp_v4,
+				    dhcp_v4_descr),
+	JSON_OBJ_DESCR_OBJ_ARRAY_NAMED(struct redfish_ethernet_interface, "IPv4Addresses",
+				       ipv4_addresses, 1, ipv4_count, ipv4_addr_descr,
+				       ARRAY_SIZE(ipv4_addr_descr)),
+	JSON_OBJ_DESCR_OBJ_ARRAY_NAMED(struct redfish_ethernet_interface, "IPv4StaticAddresses",
+				       ipv4_static_addresses, 1, ipv4_static_count, ipv4_addr_descr,
+				       ARRAY_SIZE(ipv4_addr_descr)),
 };
 
 /* PATCH /redfish/v1/Managers/bmc/EthernetInterfaces/eth0 */
@@ -970,8 +960,7 @@ static int ethernet_patch_handler(struct http_resource_user_data *user_data)
 	memset(&payload, 0, sizeof(payload));
 	payload.dhcp_v4.dhcp_enabled = 0xff; /* sentinel */
 	payload.ipv4_static_count = -1;
-	ret = json_obj_parse(user_data->data_buffer, user_data->data_len,
-			     ethernet_interface_descr,
+	ret = json_obj_parse(user_data->data_buffer, user_data->data_len, ethernet_interface_descr,
 			     ARRAY_SIZE(ethernet_interface_descr), &payload);
 	if (ret < 0) {
 		LOG_ERR("eth0: Bad JSON (err=%d)", ret);
@@ -1024,16 +1013,20 @@ static int ethernet_get_handler(struct http_resource_user_data *user_data)
 		.id = "eth0",
 		.name = "BMC Ethernet Interface",
 		.host_name = net_hostname_get(),
-		.dhcp_v4 = { .dhcp_enabled = config_bmc_use_dhcp4(), },
+		.dhcp_v4 =
+			{
+				.dhcp_enabled = config_bmc_use_dhcp4(),
+			},
 		.ipv4_count = 0,
 		.ipv4_static_count = 0,
-		.ipv4_static_addresses = {
+		.ipv4_static_addresses =
 			{
-				.address = "0.0.0.0",
-				.subnet_mask = "0.0.0.0",
-				.gateway = "0.0.0.0",
+				{
+					.address = "0.0.0.0",
+					.subnet_mask = "0.0.0.0",
+					.gateway = "0.0.0.0",
+				},
 			},
-		},
 	};
 	int ret;
 
@@ -1050,7 +1043,8 @@ static int ethernet_get_handler(struct http_resource_user_data *user_data)
 
 			if (addr->ipv4.is_used) {
 				ethernet_interface.ipv4_count = 1;
-				net_addr_ntop(AF_INET, &addr->ipv4.address.in_addr, ip_str, sizeof(ip_str));
+				net_addr_ntop(AF_INET, &addr->ipv4.address.in_addr, ip_str,
+					      sizeof(ip_str));
 				redfish_addr->address = ip_str;
 				net_addr_ntop(AF_INET, &addr->netmask, nm_str, sizeof(nm_str));
 				redfish_addr->subnet_mask = nm_str;
@@ -1080,7 +1074,8 @@ static int ethernet_get_handler(struct http_resource_user_data *user_data)
 	}
 
 	if (config_bmc_default_ip4()) {
-		struct redfish_ipv4_addr *redfish_static_addr = &ethernet_interface.ipv4_static_addresses[0];
+		struct redfish_ipv4_addr *redfish_static_addr =
+			&ethernet_interface.ipv4_static_addresses[0];
 		char static_ip_str[NET_IPV4_ADDR_LEN];
 		char static_nm_str[NET_IPV4_ADDR_LEN];
 		char static_gw_str[NET_IPV4_ADDR_LEN];
@@ -1102,7 +1097,7 @@ static int ethernet_get_handler(struct http_resource_user_data *user_data)
 	}
 
 	ret = json_obj_encode(ethernet_interface_descr, ARRAY_SIZE(ethernet_interface_descr),
-				&ethernet_interface, user_data_json_append, user_data);
+			      &ethernet_interface, user_data_json_append, user_data);
 	if (ret < 0) {
 		LOG_ERR("Failed to encode ethernet interface: %d", ret);
 		return HTTP_500_INTERNAL_SERVER_ERROR;
@@ -1122,8 +1117,10 @@ struct redfish_ntp {
 	size_t ntp_servers_count;
 };
 static const struct json_obj_descr ntp_descr[] = {
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_ntp , "ProtocolEnabled", protocol_enabled, JSON_TOK_TRUE),
-	JSON_OBJ_DESCR_ARRAY_NAMED(struct redfish_ntp , "NTPServers", ntp_servers, 1, ntp_servers_count, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_ntp, "ProtocolEnabled", protocol_enabled,
+				  JSON_TOK_TRUE),
+	JSON_OBJ_DESCR_ARRAY_NAMED(struct redfish_ntp, "NTPServers", ntp_servers, 1,
+				   ntp_servers_count, JSON_TOK_STRING),
 };
 
 /* NetworkProtocol */
@@ -1133,7 +1130,8 @@ struct redfish_network_protocol {
 	struct redfish_ntp ntp;
 };
 static const struct json_obj_descr network_protocol_descr[] = {
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_network_protocol, "@odata.type", odata_type, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_network_protocol, "@odata.type", odata_type,
+				  JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_network_protocol, "Id", id, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_network_protocol, "NTP", ntp, ntp_descr),
 };
@@ -1148,8 +1146,7 @@ static int network_protocol_patch_handler(struct http_resource_user_data *user_d
 	payload.ntp.protocol_enabled = 0xff; /* sentinel */
 	payload.ntp.ntp_servers_count = -1;
 
-	ret = json_obj_parse(user_data->data_buffer, user_data->data_len,
-			     network_protocol_descr,
+	ret = json_obj_parse(user_data->data_buffer, user_data->data_len, network_protocol_descr,
 			     ARRAY_SIZE(network_protocol_descr), &payload);
 	if (ret < 0) {
 		LOG_ERR("NetworkProtocol: Bad JSON (err=%d)", ret);
@@ -1177,9 +1174,10 @@ static int network_protocol_get_handler(struct http_resource_user_data *user_dat
 	struct redfish_network_protocol network_protocol = {
 		.odata_type = "#ManagerNetworkProtocol.v1_9_0.ManagerNetworkProtocol",
 		.id = "NetworkProtocol",
-		.ntp = {
-			.protocol_enabled = config_bmc_use_ntp(),
-		},
+		.ntp =
+			{
+				.protocol_enabled = config_bmc_use_ntp(),
+			},
 	};
 	int ret;
 
@@ -1189,7 +1187,7 @@ static int network_protocol_get_handler(struct http_resource_user_data *user_dat
 	}
 
 	ret = json_obj_encode(network_protocol_descr, ARRAY_SIZE(network_protocol_descr),
-				&network_protocol, user_data_json_append, user_data);
+			      &network_protocol, user_data_json_append, user_data);
 	if (ret < 0) {
 		LOG_ERR("Failed to encode network protocol: %d", ret);
 		return HTTP_500_INTERNAL_SERVER_ERROR;
@@ -1211,17 +1209,12 @@ static int systems_collection_get_handler(struct http_resource_user_data *user_d
 		.odata_type = "#ComputerSystemCollection.ComputerSystemCollection",
 		.name = "Computer System Collection",
 		.members_count = 1,
-		.members = {
-			{
-				.odata_id = "/redfish/v1/Systems/system"
-			}
-		},
-		.members_len = 1
-	};
+		.members = {{.odata_id = "/redfish/v1/Systems/system"}},
+		.members_len = 1};
 	int ret;
 
-	ret = json_obj_encode(collection_descr, ARRAY_SIZE(collection_descr),
-				&systems_collection, user_data_json_append, user_data);
+	ret = json_obj_encode(collection_descr, ARRAY_SIZE(collection_descr), &systems_collection,
+			      user_data_json_append, user_data);
 	if (ret < 0) {
 		LOG_ERR("Failed to encode systems collection: %d", ret);
 		return HTTP_500_INTERNAL_SERVER_ERROR;
@@ -1230,8 +1223,7 @@ static int systems_collection_get_handler(struct http_resource_user_data *user_d
 	return 0;
 }
 
-REDFISH_HANDLER(systems_collection, "/redfish/v1/Systems",
-		true, /* require auth */
+REDFISH_HANDLER(systems_collection, "/redfish/v1/Systems", true, /* require auth */
 		systems_collection_get_handler, NULL, NULL);
 
 /*** /redfish/v1/Systems/system ***/
@@ -1245,10 +1237,8 @@ struct redfish_reset_action {
 };
 static const struct json_obj_descr reset_action_descr[] = {
 	JSON_OBJ_DESCR_PRIM(struct redfish_reset_action, target, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_ARRAY_NAMED(struct redfish_reset_action,
-				   "ResetType@Redfish.AllowableValues",
-				   reset_type_values, 3, reset_type_values_len,
-				   JSON_TOK_STRING),
+	JSON_OBJ_DESCR_ARRAY_NAMED(struct redfish_reset_action, "ResetType@Redfish.AllowableValues",
+				   reset_type_values, 3, reset_type_values_len, JSON_TOK_STRING),
 };
 
 /* System Info: Actions nested object */
@@ -1256,8 +1246,8 @@ struct redfish_actions {
 	struct redfish_reset_action reset_action;
 };
 static const struct json_obj_descr actions_descr[] = {
-	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_actions, "#ComputerSystem.Reset",
-				    reset_action, reset_action_descr),
+	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_actions, "#ComputerSystem.Reset", reset_action,
+				    reset_action_descr),
 };
 
 /* System Info: ProcessorSummary nested object */
@@ -1267,15 +1257,15 @@ struct redfish_processor_summary {
 	const char *model;
 };
 static const struct json_obj_descr processor_summary_descr[] = {
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_processor_summary, "Count",
-				  count, JSON_TOK_NUMBER),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_processor_summary, "Model",
-				  model, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_processor_summary, "Count", count,
+				  JSON_TOK_NUMBER),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_processor_summary, "Model", model,
+				  JSON_TOK_STRING),
 };
 
 /* System Info: MemorySummary nested object */
-#define REDFISH_SYSTEM_CHASSIS_MAX	1
-#define REDFISH_SYSTEM_MANAGERS_MAX	1
+#define REDFISH_SYSTEM_CHASSIS_MAX  1
+#define REDFISH_SYSTEM_MANAGERS_MAX 1
 
 struct redfish_system_links {
 	size_t chassis_len;
@@ -1284,14 +1274,12 @@ struct redfish_system_links {
 	struct redfish_link managed_by[REDFISH_SYSTEM_MANAGERS_MAX];
 };
 static const struct json_obj_descr system_links_descr[] = {
-	JSON_OBJ_DESCR_OBJ_ARRAY_NAMED(struct redfish_system_links,
-				       "Chassis", chassis,
-				       REDFISH_SYSTEM_CHASSIS_MAX, chassis_len,
-				       link_descr, ARRAY_SIZE(link_descr)),
-	JSON_OBJ_DESCR_OBJ_ARRAY_NAMED(struct redfish_system_links,
-				       "ManagedBy", managed_by,
-				       REDFISH_SYSTEM_MANAGERS_MAX, managed_by_len,
-				       link_descr, ARRAY_SIZE(link_descr)),
+	JSON_OBJ_DESCR_OBJ_ARRAY_NAMED(struct redfish_system_links, "Chassis", chassis,
+				       REDFISH_SYSTEM_CHASSIS_MAX, chassis_len, link_descr,
+				       ARRAY_SIZE(link_descr)),
+	JSON_OBJ_DESCR_OBJ_ARRAY_NAMED(struct redfish_system_links, "ManagedBy", managed_by,
+				       REDFISH_SYSTEM_MANAGERS_MAX, managed_by_len, link_descr,
+				       ARRAY_SIZE(link_descr)),
 };
 
 struct redfish_memory_summary {
@@ -1321,36 +1309,32 @@ struct redfish_computer_system {
 	struct redfish_system_links links;
 };
 static const struct json_obj_descr computer_system_descr[] = {
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "@odata.id",
-				  odata_id, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "@odata.type",
-				  odata_type, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "Id",
-				  id, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "UUID",
-				  uuid, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "Name",
-				  name, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "SystemType",
-				  system_type, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "Manufacturer",
-				  manufacturer, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "Model",
-				  model, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "SerialNumber",
-				  serial_number, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "@odata.id", odata_id,
+				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "@odata.type", odata_type,
+				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "Id", id, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "UUID", uuid, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "Name", name, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "SystemType", system_type,
+				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "Manufacturer", manufacturer,
+				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "Model", model, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "SerialNumber", serial_number,
+				  JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "PowerRestorePolicy",
 				  power_restore_policy, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "PowerState",
-				  power_state, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_computer_system, "PowerState", power_state,
+				  JSON_TOK_STRING),
 	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_computer_system, "ProcessorSummary",
 				    processor_summary, processor_summary_descr),
-	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_computer_system, "MemorySummary",
-				    memory_summary, memory_summary_descr),
-	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_computer_system, "Links",
-				    links, system_links_descr),
-	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_computer_system, "Actions",
-				    actions, actions_descr),
+	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_computer_system, "MemorySummary", memory_summary,
+				    memory_summary_descr),
+	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_computer_system, "Links", links,
+				    system_links_descr),
+	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_computer_system, "Actions", actions,
+				    actions_descr),
 };
 
 /* PATCH /redfish/v1/Systems/system */
@@ -1360,8 +1344,7 @@ static int system_patch_handler(struct http_resource_user_data *user_data)
 	int ret;
 
 	memset(&payload, 0, sizeof(payload));
-	ret = json_obj_parse(user_data->data_buffer, user_data->data_len,
-			     computer_system_descr,
+	ret = json_obj_parse(user_data->data_buffer, user_data->data_len, computer_system_descr,
 			     ARRAY_SIZE(computer_system_descr), &payload);
 	if (ret < 0) {
 		LOG_ERR("System: Bad JSON (err=%d)", ret);
@@ -1399,46 +1382,40 @@ static int system_get_handler(struct http_resource_user_data *user_data)
 		.manufacturer = CONFIG_REDFISH_SYSTEM_MANUFACTURER,
 		.model = CONFIG_REDFISH_SYSTEM_MODEL,
 		.serial_number = serial_number,
-		.processor_summary = {
-			.odata_type = "#ProcessorSummary.v1_4_0.ProcessorSummary",
-			.count = CONFIG_REDFISH_SYSTEM_PROCESSOR_COUNT,
-			.model = CONFIG_REDFISH_SYSTEM_PROCESSOR_MODEL,
-		},
-		.memory_summary = {
-			.total_system_GiB = CONFIG_REDFISH_SYSTEM_MEMORY_GIB,
-		},
+		.processor_summary =
+			{
+				.odata_type = "#ProcessorSummary.v1_4_0.ProcessorSummary",
+				.count = CONFIG_REDFISH_SYSTEM_PROCESSOR_COUNT,
+				.model = CONFIG_REDFISH_SYSTEM_PROCESSOR_MODEL,
+			},
+		.memory_summary =
+			{
+				.total_system_GiB = CONFIG_REDFISH_SYSTEM_MEMORY_GIB,
+			},
 		.power_restore_policy = config_host_auto_poweron() ? "AlwaysOn" : "AlwaysOff",
 		.power_state = power_get_state() ? "On" : "Off",
-		.links = {
-			.chassis_len = 1,
-			.chassis = {
-				{
-					.odata_id = "/redfish/v1/Chassis/1"
-				},
+		.links =
+			{
+				.chassis_len = 1,
+				.chassis =
+					{
+						{.odata_id = "/redfish/v1/Chassis/1"},
+					},
+				.managed_by_len = 1,
+				.managed_by =
+					{
+						{.odata_id = "/redfish/v1/Managers/bmc"},
+					},
 			},
-			.managed_by_len = 1,
-			.managed_by = {
-				{
-					.odata_id = "/redfish/v1/Managers/bmc"
-				},
-			},
-		},
 		.actions = {
 			.reset_action = {
 				.target = "/redfish/v1/Systems/system/Actions/ComputerSystem.Reset",
-				.reset_type_values = {
-					"On",
-					"ForceOff",
-					"PowerCycle"
-				},
-				.reset_type_values_len = 3
-			}
-		}
-	};
+				.reset_type_values = {"On", "ForceOff", "PowerCycle"},
+				.reset_type_values_len = 3}}};
 	int ret;
 
 	ret = json_obj_encode(computer_system_descr, ARRAY_SIZE(computer_system_descr),
-				&computer_system, user_data_json_append, user_data);
+			      &computer_system, user_data_json_append, user_data);
 	if (ret < 0) {
 		LOG_ERR("Failed to encode computer system: %d", ret);
 		return HTTP_500_INTERNAL_SERVER_ERROR;
@@ -1447,17 +1424,14 @@ static int system_get_handler(struct http_resource_user_data *user_data)
 	return 0;
 }
 
-REDFISH_HANDLER(system, "/redfish/v1/Systems/system",
-		true, /* require auth */
+REDFISH_HANDLER(system, "/redfish/v1/Systems/system", true, /* require auth */
 		system_get_handler, system_patch_handler, NULL);
 
 struct redfish_reset_payload {
 	const char *reset_type;
 };
-static const struct json_obj_descr reset_descr[] = {
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_reset_payload, "ResetType",
-				  reset_type, JSON_TOK_STRING)
-};
+static const struct json_obj_descr reset_descr[] = {JSON_OBJ_DESCR_PRIM_NAMED(
+	struct redfish_reset_payload, "ResetType", reset_type, JSON_TOK_STRING)};
 
 /* POST /redfish/v1/Systems/system/Actions/ComputerSystem.Reset */
 static int system_reset_post_handler(struct http_resource_user_data *user_data)
@@ -1466,8 +1440,8 @@ static int system_reset_post_handler(struct http_resource_user_data *user_data)
 	int ret;
 
 	memset(&payload, 0, sizeof(payload));
-	ret = json_obj_parse(user_data->data_buffer, user_data->data_len,
-			     reset_descr, ARRAY_SIZE(reset_descr), &payload);
+	ret = json_obj_parse(user_data->data_buffer, user_data->data_len, reset_descr,
+			     ARRAY_SIZE(reset_descr), &payload);
 	if (ret < 0) {
 		LOG_ERR("ComputerSystem.Reset: Bad JSON (err=%d)", ret);
 		return HTTP_400_BAD_REQUEST;
@@ -1502,17 +1476,12 @@ static int chassis_collection_get_handler(struct http_resource_user_data *user_d
 		.odata_type = "#ChassisCollection.ChassisCollection",
 		.name = "Chassis Collection",
 		.members_count = 1,
-		.members = {
-			{
-				.odata_id = "/redfish/v1/Chassis/1"
-			}
-		},
-		.members_len = 1
-	};
+		.members = {{.odata_id = "/redfish/v1/Chassis/1"}},
+		.members_len = 1};
 	int ret;
 
-	ret = json_obj_encode(collection_descr, ARRAY_SIZE(collection_descr),
-			      &chassis_collection, user_data_json_append, user_data);
+	ret = json_obj_encode(collection_descr, ARRAY_SIZE(collection_descr), &chassis_collection,
+			      user_data_json_append, user_data);
 	if (ret < 0) {
 		LOG_ERR("Failed to encode chassis collection: %d", ret);
 		return HTTP_500_INTERNAL_SERVER_ERROR;
@@ -1521,12 +1490,11 @@ static int chassis_collection_get_handler(struct http_resource_user_data *user_d
 	return 0;
 }
 
-REDFISH_HANDLER(chassis_collection, "/redfish/v1/Chassis",
-		true, /* require auth */
+REDFISH_HANDLER(chassis_collection, "/redfish/v1/Chassis", true, /* require auth */
 		chassis_collection_get_handler, NULL, NULL);
 
 /*** /redfish/v1/Chassis/1 ***/
-#define REDFISH_CHASSIS_COMPUTER_SYSTEMS_MAX	1
+#define REDFISH_CHASSIS_COMPUTER_SYSTEMS_MAX 1
 
 struct redfish_chassis_links {
 	size_t computer_systems_len;
@@ -1535,14 +1503,12 @@ struct redfish_chassis_links {
 	struct redfish_link managed_by[REDFISH_SYSTEM_MANAGERS_MAX];
 };
 static const struct json_obj_descr chassis_links_descr[] = {
-	JSON_OBJ_DESCR_OBJ_ARRAY_NAMED(struct redfish_chassis_links,
-				       "ComputerSystems", computer_systems,
-				       REDFISH_CHASSIS_COMPUTER_SYSTEMS_MAX, computer_systems_len,
-				       link_descr, ARRAY_SIZE(link_descr)),
-	JSON_OBJ_DESCR_OBJ_ARRAY_NAMED(struct redfish_chassis_links,
-				       "ManagedBy", managed_by,
-				       REDFISH_SYSTEM_MANAGERS_MAX, managed_by_len,
-				       link_descr, ARRAY_SIZE(link_descr)),
+	JSON_OBJ_DESCR_OBJ_ARRAY_NAMED(struct redfish_chassis_links, "ComputerSystems",
+				       computer_systems, REDFISH_CHASSIS_COMPUTER_SYSTEMS_MAX,
+				       computer_systems_len, link_descr, ARRAY_SIZE(link_descr)),
+	JSON_OBJ_DESCR_OBJ_ARRAY_NAMED(struct redfish_chassis_links, "ManagedBy", managed_by,
+				       REDFISH_SYSTEM_MANAGERS_MAX, managed_by_len, link_descr,
+				       ARRAY_SIZE(link_descr)),
 };
 
 struct redfish_chassis {
@@ -1559,28 +1525,22 @@ struct redfish_chassis {
 	struct redfish_chassis_links links;
 };
 static const struct json_obj_descr chassis_descr[] = {
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_chassis, "@odata.id",
-				  odata_id, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_chassis, "@odata.type",
-				  odata_type, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_chassis, "Id",
-				  id, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_chassis, "Name",
-				  name, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_chassis, "ChassisType",
-				  chassis_type, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_chassis, "Manufacturer",
-				  manufacturer, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_chassis, "Model",
-				  model, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_chassis, "SerialNumber",
-				  serial_number, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_chassis, "PowerState",
-				  power_state, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_chassis, "Sensors",
-				    sensors, link_descr),
-	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_chassis, "Links",
-				    links, chassis_links_descr),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_chassis, "@odata.id", odata_id, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_chassis, "@odata.type", odata_type,
+				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_chassis, "Id", id, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_chassis, "Name", name, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_chassis, "ChassisType", chassis_type,
+				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_chassis, "Manufacturer", manufacturer,
+				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_chassis, "Model", model, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_chassis, "SerialNumber", serial_number,
+				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_chassis, "PowerState", power_state,
+				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_chassis, "Sensors", sensors, link_descr),
+	JSON_OBJ_DESCR_OBJECT_NAMED(struct redfish_chassis, "Links", links, chassis_links_descr),
 };
 
 /* GET /redfish/v1/Chassis/1 */
@@ -1596,28 +1556,25 @@ static int chassis_get_handler(struct http_resource_user_data *user_data)
 		.model = CONFIG_REDFISH_SYSTEM_MODEL,
 		.serial_number = serial_number,
 		.power_state = power_get_state() ? "On" : "Off",
-		.sensors = {
-			.odata_id = "/redfish/v1/Chassis/1/Sensors"
-		},
-		.links = {
-			.computer_systems_len = 1,
-			.computer_systems = {
-				{
-					.odata_id = "/redfish/v1/Systems/system"
-				},
+		.sensors = {.odata_id = "/redfish/v1/Chassis/1/Sensors"},
+		.links =
+			{
+				.computer_systems_len = 1,
+				.computer_systems =
+					{
+						{.odata_id = "/redfish/v1/Systems/system"},
+					},
+				.managed_by_len = 1,
+				.managed_by =
+					{
+						{.odata_id = "/redfish/v1/Managers/bmc"},
+					},
 			},
-			.managed_by_len = 1,
-			.managed_by = {
-				{
-					.odata_id = "/redfish/v1/Managers/bmc"
-				},
-			},
-		},
 	};
 	int ret;
 
-	ret = json_obj_encode(chassis_descr, ARRAY_SIZE(chassis_descr),
-			      &chassis, user_data_json_append, user_data);
+	ret = json_obj_encode(chassis_descr, ARRAY_SIZE(chassis_descr), &chassis,
+			      user_data_json_append, user_data);
 	if (ret < 0) {
 		LOG_ERR("Failed to encode chassis: %d", ret);
 		return HTTP_500_INTERNAL_SERVER_ERROR;
@@ -1626,16 +1583,15 @@ static int chassis_get_handler(struct http_resource_user_data *user_data)
 	return 0;
 }
 
-REDFISH_HANDLER(chassis, "/redfish/v1/Chassis/1",
-		true, /* require auth */
+REDFISH_HANDLER(chassis, "/redfish/v1/Chassis/1", true, /* require auth */
 		chassis_get_handler, NULL, NULL);
 
 /*** /redfish/v1/Chassis/1/Sensors ***/
 
 #ifdef CONFIG_APP_SENSORS
-#define REDFISH_SENSORS_MEMBERS_MAX	1
+#define REDFISH_SENSORS_MEMBERS_MAX 1
 #else
-#define REDFISH_SENSORS_MEMBERS_MAX	0
+#define REDFISH_SENSORS_MEMBERS_MAX 0
 #endif
 
 /* GET /redfish/v1/Chassis/1/Sensors */
@@ -1647,11 +1603,7 @@ static int sensors_collection_get_handler(struct http_resource_user_data *user_d
 		.name = "Chassis Sensor Collection",
 		.members_count = REDFISH_SENSORS_MEMBERS_MAX,
 #ifdef CONFIG_APP_SENSORS
-		.members = {
-			{
-				.odata_id = "/redfish/v1/Chassis/1/Sensors/TempBmc"
-			}
-		},
+		.members = {{.odata_id = "/redfish/v1/Chassis/1/Sensors/TempBmc"}},
 		.members_len = 1,
 #else
 		.members_len = 0,
@@ -1659,8 +1611,8 @@ static int sensors_collection_get_handler(struct http_resource_user_data *user_d
 	};
 	int ret;
 
-	ret = json_obj_encode(collection_descr, ARRAY_SIZE(collection_descr),
-			      &sensors_collection, user_data_json_append, user_data);
+	ret = json_obj_encode(collection_descr, ARRAY_SIZE(collection_descr), &sensors_collection,
+			      user_data_json_append, user_data);
 	if (ret < 0) {
 		LOG_ERR("Failed to encode sensors collection: %d", ret);
 		return HTTP_500_INTERNAL_SERVER_ERROR;
@@ -1669,8 +1621,7 @@ static int sensors_collection_get_handler(struct http_resource_user_data *user_d
 	return 0;
 }
 
-REDFISH_HANDLER(sensors_collection, "/redfish/v1/Chassis/1/Sensors",
-		true, /* require auth */
+REDFISH_HANDLER(sensors_collection, "/redfish/v1/Chassis/1/Sensors", true, /* require auth */
 		sensors_collection_get_handler, NULL, NULL);
 
 /*** /redfish/v1/Chassis/1/Sensors/TempBmc ***/
@@ -1687,22 +1638,18 @@ struct redfish_sensor {
 	const char *physical_context;
 };
 static const struct json_obj_descr sensor_descr[] = {
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_sensor, "@odata.id",
-				  odata_id, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_sensor, "@odata.type",
-				  odata_type, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_sensor, "Id",
-				  id, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_sensor, "Name",
-				  name, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_sensor, "Reading",
-				  reading, JSON_TOK_NUMBER),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_sensor, "ReadingType",
-				  reading_type, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_sensor, "ReadingUnits",
-				  reading_units, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_sensor, "PhysicalContext",
-				  physical_context, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_sensor, "@odata.id", odata_id, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_sensor, "@odata.type", odata_type,
+				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_sensor, "Id", id, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_sensor, "Name", name, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_sensor, "Reading", reading, JSON_TOK_NUMBER),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_sensor, "ReadingType", reading_type,
+				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_sensor, "ReadingUnits", reading_units,
+				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct redfish_sensor, "PhysicalContext", physical_context,
+				  JSON_TOK_STRING),
 };
 
 /* GET /redfish/v1/Chassis/1/Sensors/TempBmc */
@@ -1730,8 +1677,8 @@ static int sensor_temp_bmc_get_handler(struct http_resource_user_data *user_data
 		sensor_temp_bmc.reading = val.val1;
 	}
 
-	ret = json_obj_encode(sensor_descr, ARRAY_SIZE(sensor_descr),
-			      &sensor_temp_bmc, user_data_json_append, user_data);
+	ret = json_obj_encode(sensor_descr, ARRAY_SIZE(sensor_descr), &sensor_temp_bmc,
+			      user_data_json_append, user_data);
 	if (ret < 0) {
 		LOG_ERR("Failed to encode Sensor TempBmc: %d", ret);
 		return HTTP_500_INTERNAL_SERVER_ERROR;
@@ -1740,8 +1687,7 @@ static int sensor_temp_bmc_get_handler(struct http_resource_user_data *user_data
 	return 0;
 }
 
-REDFISH_HANDLER(sensor_temp_bmc, "/redfish/v1/Chassis/1/Sensors/TempBmc",
-		true, /* require auth */
+REDFISH_HANDLER(sensor_temp_bmc, "/redfish/v1/Chassis/1/Sensors/TempBmc", true, /* require auth */
 		sensor_temp_bmc_get_handler, NULL, NULL);
 #endif /* CONFIG_APP_SENSORS */
 
@@ -1751,7 +1697,8 @@ static const uint8_t redfish_metadata_xml_gz[] = {
 };
 
 static struct http_resource_detail_static redfish_metadata_xml_gz_resource_detail = {
-	.common = {
+	.common =
+		{
 			.type = HTTP_RESOURCE_TYPE_STATIC,
 			.bitmask_of_supported_http_methods = BIT(HTTP_GET),
 			.content_encoding = "gzip",
@@ -1761,9 +1708,9 @@ static struct http_resource_detail_static redfish_metadata_xml_gz_resource_detai
 	.static_data_len = sizeof(redfish_metadata_xml_gz),
 };
 
-HTTP_RESOURCE_DEFINE(redfish_metadata_xml_gz_resource, http_service,
-		"/redfish/v1/$metadata", &redfish_metadata_xml_gz_resource_detail);
+HTTP_RESOURCE_DEFINE(redfish_metadata_xml_gz_resource, http_service, "/redfish/v1/$metadata",
+		     &redfish_metadata_xml_gz_resource_detail);
 #if defined(CONFIG_APP_HTTPS)
-HTTP_RESOURCE_DEFINE(redfish_metadata_xml_gz_resource_https, https_service,
-		"/redfish/v1/$metadata", &redfish_metadata_xml_gz_resource_detail);
+HTTP_RESOURCE_DEFINE(redfish_metadata_xml_gz_resource_https, https_service, "/redfish/v1/$metadata",
+		     &redfish_metadata_xml_gz_resource_detail);
 #endif /* defined(CONFIG_APP_HTTPS) */

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -7,8 +7,8 @@
 #include <zephyr/logging/log_ctrl.h>
 LOG_MODULE_REGISTER(wallabmc_rtc, LOG_LEVEL_INF);
 
-#include <zephyr/kernel.h>
 #include <zephyr/drivers/rtc.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/timeutil.h>
 
 #include "rtc.h"
@@ -35,8 +35,7 @@ int rtc_set_from_timespec(const struct timespec *ts)
 		return ret;
 	}
 
-	LOG_INF("RTC: %04d-%02d-%02d %02d:%02d:%02d",
-		tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+	LOG_INF("RTC: %04d-%02d-%02d %02d:%02d:%02d", tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
 		tm.tm_hour, tm.tm_min, tm.tm_sec);
 
 	return 0;
@@ -71,8 +70,8 @@ static int time_iso_to_ts(const char *str, struct timespec *ts)
 
 	memset(&tm, 0, sizeof(struct tm));
 
-	ret = sscanf(str, "%d-%d-%dT%d:%d:%d.%3dZ",
-			&year, &month, &day, &hour, &minute, &second, &frac);
+	ret = sscanf(str, "%d-%d-%dT%d:%d:%d.%3dZ", &year, &month, &day, &hour, &minute, &second,
+		     &frac);
 	if (ret != 7)
 		return -EINVAL;
 	if (year < 1900)
@@ -81,11 +80,11 @@ static int time_iso_to_ts(const char *str, struct timespec *ts)
 		return -EINVAL;
 
 	tm.tm_year = year - 1900;
-	tm.tm_mon  = month - 1;
+	tm.tm_mon = month - 1;
 	tm.tm_mday = day;
 	tm.tm_hour = hour;
-	tm.tm_min  = minute;
-	tm.tm_sec  = second;
+	tm.tm_min = minute;
+	tm.tm_sec = second;
 
 	epoch_sec = timeutil_timegm(&tm);
 	if (epoch_sec == -1)
@@ -160,8 +159,7 @@ int rtc_init(void)
 		return ret;
 	}
 
-	LOG_INF("RTC: %04d-%02d-%02d %02d:%02d:%02d",
-		tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+	LOG_INF("RTC: %04d-%02d-%02d %02d:%02d:%02d", tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
 		tm.tm_hour, tm.tm_min, tm.tm_sec);
 
 	ts.tv_sec = timeutil_timegm(rtc_time_to_tm(&tm));

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -9,7 +9,7 @@
 int rtc_init(void);
 int rtc_set_from_clock(void);
 int time_set_from_iso_str(const char *str);
-#else /* defined(CONFIG_RTC) */
+#else  /* defined(CONFIG_RTC) */
 static inline int rtc_init(void) { return 0; }
 static inline int rtc_set_from_clock(void) { return -ENODEV; }
 static inline int time_set_from_iso_str(void) { return -ENODEV; }

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/sensor.h>
+#include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
 
 #include "main.h"
@@ -69,15 +69,11 @@ static int cmd_show_sensors(const struct shell *sh, size_t argc, char **argv)
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_sensors_cmds,
-	SHELL_CMD(show,		NULL, "Show sensors.", cmd_show_sensors),
-	SHELL_SUBCMD_SET_END
-);
+			       SHELL_CMD(show, NULL, "Show sensors.", cmd_show_sensors),
+			       SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(sensors, &sub_sensors_cmds, "Sensors commands", NULL);
 
 #else
-int read_die_temperature(struct sensor_value *val)
-{
-	return -ENODEV;
-}
+int read_die_temperature(struct sensor_value *val) { return -ENODEV; }
 #endif

--- a/src/sensors.h
+++ b/src/sensors.h
@@ -10,10 +10,7 @@
 #ifdef CONFIG_APP_SENSORS
 int read_die_temperature(struct sensor_value *val);
 #else
-static inline int read_die_temperature(struct sensor_value *val)
-{
-	return -ENODEV;
-}
+static inline int read_die_temperature(struct sensor_value *val) { return -ENODEV; }
 #endif
 
 #endif

--- a/src/synch.h
+++ b/src/synch.h
@@ -7,9 +7,9 @@
 
 #include <zephyr/kernel.h>
 
-#define EVENT_CONSOLE_LOG_DATA		0x0001
-#define EVENT_WEBSOCKET_CLIENT		0x0002
-#define EVENT_TELNET_CLIENT		0x0004
+#define EVENT_CONSOLE_LOG_DATA 0x0001
+#define EVENT_WEBSOCKET_CLIENT 0x0002
+#define EVENT_TELNET_CLIENT    0x0004
 
 extern struct k_event events;
 

--- a/src/vpd.c
+++ b/src/vpd.c
@@ -6,12 +6,12 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(wallabmc_vpd, LOG_LEVEL_INF);
 
-#include <zephyr/sys/uuid.h>
 #include <zephyr/drivers/hwinfo.h>
+#include <zephyr/sys/uuid.h>
 #include <zephyr/version.h>
 
-#include "vpd.h"
 #include "git_sha.h"
+#include "vpd.h"
 
 #ifdef CONFIG_SHELL
 #include <zephyr/shell/shell.h>
@@ -37,10 +37,8 @@ static int cmd_vpd_show(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_vpd_cmds,
-	SHELL_CMD(show, NULL, "Show VPD.", cmd_vpd_show),
-	SHELL_SUBCMD_SET_END
-);
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_vpd_cmds, SHELL_CMD(show, NULL, "Show VPD.", cmd_vpd_show),
+			       SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(vpd, &sub_vpd_cmds, "Vital product data", NULL);
 #endif /* CONFIG_SHELL */

--- a/src/web.c
+++ b/src/web.c
@@ -8,11 +8,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdio.h>
+#include <zephyr/data/json.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net/http/server.h>
 #include <zephyr/net/http/service.h>
-#include <zephyr/data/json.h>
-#include <stdio.h>
 
 #include "power.h"
 
@@ -24,7 +24,8 @@ static const uint8_t index_html_gz[] = {
 };
 
 static struct http_resource_detail_static index_html_gz_resource_detail = {
-	.common = {
+	.common =
+		{
 			.type = HTTP_RESOURCE_TYPE_STATIC,
 			.bitmask_of_supported_http_methods = BIT(HTTP_GET),
 			.content_encoding = "gzip",
@@ -39,7 +40,8 @@ static const uint8_t logo_jpeg_gz[] = {
 };
 
 static struct http_resource_detail_static logo_jpeg_gz_resource_detail = {
-	.common = {
+	.common =
+		{
 			.type = HTTP_RESOURCE_TYPE_STATIC,
 			.bitmask_of_supported_http_methods = BIT(HTTP_GET),
 			.content_encoding = "gzip",
@@ -54,7 +56,8 @@ static const uint8_t favicon_png_gz[] = {
 };
 
 static struct http_resource_detail_static favicon_png_gz_resource_detail = {
-	.common = {
+	.common =
+		{
 			.type = HTTP_RESOURCE_TYPE_STATIC,
 			.bitmask_of_supported_http_methods = BIT(HTTP_GET),
 			.content_encoding = "gzip",
@@ -64,8 +67,7 @@ static struct http_resource_detail_static favicon_png_gz_resource_detail = {
 	.static_data_len = sizeof(favicon_png_gz),
 };
 
-HTTP_RESOURCE_DEFINE(index_html_gz_resource, http_service, "/",
-		     &index_html_gz_resource_detail);
+HTTP_RESOURCE_DEFINE(index_html_gz_resource, http_service, "/", &index_html_gz_resource_detail);
 HTTP_RESOURCE_DEFINE(logo_jpeg_gz_resource, http_service, "/logo.jpeg",
 		     &logo_jpeg_gz_resource_detail);
 HTTP_RESOURCE_DEFINE(favicon_png_gz_resource, http_service, "/favicon.png",


### PR DESCRIPTION
We should have done this earlier, but let's get something into the tree so we can use automated formatting in future.

The style is loosely based on kernel style, but with some things tweaked to avoid causing too much churn.