### PR TITLE
feat: add fan control, power monitor, and power management improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ else()
 	endif()
 endif()
 
+target_include_directories(app PRIVATE src)
 
 zephyr_linker_sources(SECTIONS sections-rom.ld)
 zephyr_linker_section_ifdef(CONFIG_HTTP_SERVER
@@ -94,6 +95,14 @@ target_sources_ifdef(CONFIG_APP_WEB_TERMINAL_HOST_SERIAL app PRIVATE
 target_sources_ifdef(CONFIG_PERSISTENT_STORAGE app PRIVATE
 	src/button.c
 	src/fs.c
+)
+
+target_sources_ifdef(CONFIG_FAN_CONTROL app PRIVATE
+	src/fan.c
+)
+
+target_sources_ifdef(CONFIG_POWER_MONITOR app PRIVATE
+	src/power_monitor.c
 )
 
 target_sources_ifdef(CONFIG_REDFISH app PRIVATE

--- a/Kconfig
+++ b/Kconfig
@@ -419,4 +419,11 @@ config CONSOLE_BRIDGE_PRIORITY
 
 endif
 
+menu "Hardware management"
+
+rsource "src/Kconfig.power"
+rsource "src/Kconfig.fan"
+
+endmenu
+
 source "Kconfig.zephyr"

--- a/src/Kconfig.fan
+++ b/src/Kconfig.fan
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Red Hat, LLC
+# Fan PWM control and tachometer RPM sensing
+
+config FAN_CONTROL
+	bool "Fan PWM speed control"
+	default y
+	depends on PWM
+	depends on $(dt_nodelabel_enabled,pwm4)
+
+if FAN_CONTROL
+
+config FAN_DEFAULT_DUTY_PCT
+	int "Default fan duty cycle (%)"
+	range 0 100
+	default 50
+
+config FAN_PWM_PERIOD_US
+	int "PWM period (microseconds)"
+	default 40
+	help
+	  PWM period. 40us = 25kHz, standard for 4-pin PC fans.
+
+endif # FAN_CONTROL

--- a/src/Kconfig.power
+++ b/src/Kconfig.power
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Red Hat, LLC
+# Power sequencing and monitoring
+
+config POWER_SEQUENCING
+	bool "Hardware power sequencing state machine"
+	default y
+	depends on $(dt_alias_enabled,power-good)
+	help
+	  Enable multi-step power sequencing (ATX -> DC -> wait power good ->
+	  SOM reset release -> power LED) instead of simple GPIO toggle.
+
+config POWER_GOOD_TIMEOUT_MS
+	int "Power-good wait timeout (ms)"
+	default 2000
+	depends on POWER_SEQUENCING
+
+config POWER_GOOD_POLL_MS
+	int "Power-good poll interval (ms)"
+	default 200
+	depends on POWER_SEQUENCING
+
+config POWER_MONITOR
+	bool "12V rail power monitoring (INA226)"
+	default y
+	depends on SENSOR
+	depends on $(dt_nodelabel_enabled,ina226)

--- a/src/button.c
+++ b/src/button.c
@@ -45,18 +45,19 @@ static void reset_work_fn(struct k_work *work)
 
 static K_WORK_DELAYABLE_DEFINE(reset_work, reset_work_fn);
 
-#define RESET_HOLD_TIME_MS 1000
+#define RESET_HOLD_TIME_MS 10000
 
 static void button_work_fn(struct k_work *work)
 {
 	int val = gpio_pin_get_dt(&button);
 	if (val == 1) {
 		/* Pressed */
+		LOG_INF("Recovery button pressed, hold for %d seconds to factory reset",
+			RESET_HOLD_TIME_MS / 1000);
 		k_work_schedule(&reset_work, K_MSEC(RESET_HOLD_TIME_MS));
 	} else if (val == 0) {
-		/* Released */
+		/* Released before timeout */
 		k_work_cancel_delayable(&reset_work);
-		LOG_INF("Hold button for 1s to clear config and reset");
 	}
 }
 

--- a/src/fan.c
+++ b/src/fan.c
@@ -1,0 +1,190 @@
+/*
+ * SPDX-FileCopyrightText: © 2026 Red Hat, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/pwm.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/logging/log.h>
+#include <stdlib.h>
+
+LOG_MODULE_REGISTER(fan, LOG_LEVEL_INF);
+
+#define FAN_COUNT 2
+#define TACH_PULSES_PER_REV 2
+#define TACH_SAMPLE_PERIOD_MS 1000
+
+static const struct pwm_dt_spec fan_pwm[FAN_COUNT] = {
+	PWM_DT_SPEC_GET(DT_NODELABEL(fan0)),
+	PWM_DT_SPEC_GET(DT_NODELABEL(fan1)),
+};
+
+static int fan_duty[FAN_COUNT];
+
+#define FAN_TACH_0 DT_ALIAS(fan_tach_0)
+#define FAN_TACH_1 DT_ALIAS(fan_tach_1)
+
+#if DT_NODE_EXISTS(FAN_TACH_0) && DT_NODE_EXISTS(FAN_TACH_1)
+#define HAS_FAN_TACH 1
+
+static const struct gpio_dt_spec fan_tach_gpio[FAN_COUNT] = {
+	GPIO_DT_SPEC_GET(FAN_TACH_0, gpios),
+	GPIO_DT_SPEC_GET(FAN_TACH_1, gpios),
+};
+
+#define TACH_POLL_MS 5
+
+static bool fan_tach_prev[FAN_COUNT];
+static uint32_t fan_tach_count[FAN_COUNT];
+static int fan_rpm[FAN_COUNT];
+
+static void fan_tach_poll(struct k_work *work);
+static K_WORK_DELAYABLE_DEFINE(fan_tach_poll_work, fan_tach_poll);
+
+static uint32_t fan_tach_polls;
+
+static void fan_tach_poll(struct k_work *work)
+{
+	for (int i = 0; i < FAN_COUNT; i++) {
+		bool now = gpio_pin_get_dt(&fan_tach_gpio[i]) > 0;
+
+		if (now && !fan_tach_prev[i]) {
+			fan_tach_count[i]++;
+		}
+		fan_tach_prev[i] = now;
+	}
+
+	if (++fan_tach_polls >= (TACH_SAMPLE_PERIOD_MS / TACH_POLL_MS)) {
+		for (int i = 0; i < FAN_COUNT; i++) {
+			fan_rpm[i] = (fan_tach_count[i] * 60 * 1000) /
+				     (TACH_PULSES_PER_REV * TACH_SAMPLE_PERIOD_MS);
+			fan_tach_count[i] = 0;
+		}
+		fan_tach_polls = 0;
+	}
+
+	k_work_schedule(&fan_tach_poll_work, K_MSEC(TACH_POLL_MS));
+}
+#endif /* HAS_FAN_TACH */
+
+int fan_set_duty(int fan_num, int duty_pct)
+{
+	if (fan_num < 0 || fan_num >= FAN_COUNT) {
+		return -EINVAL;
+	}
+	if (duty_pct < 0 || duty_pct > 100) {
+		return -EINVAL;
+	}
+
+	uint32_t period = PWM_USEC(CONFIG_FAN_PWM_PERIOD_US);
+	uint32_t pulse = period * duty_pct / 100;
+
+	int ret = pwm_set_dt(&fan_pwm[fan_num], period, pulse);
+	if (ret < 0) {
+		LOG_ERR("Failed to set fan %d duty to %d%%: %d",
+			fan_num, duty_pct, ret);
+		return ret;
+	}
+
+	fan_duty[fan_num] = duty_pct;
+	LOG_INF("Fan %d duty set to %d%%", fan_num, duty_pct);
+	return 0;
+}
+
+int fan_get_duty(int fan_num)
+{
+	if (fan_num < 0 || fan_num >= FAN_COUNT) {
+		return -EINVAL;
+	}
+	return fan_duty[fan_num];
+}
+
+int fan_get_rpm(int fan_num)
+{
+#ifdef HAS_FAN_TACH
+	if (fan_num >= 0 && fan_num < FAN_COUNT) {
+		return fan_rpm[fan_num];
+	}
+#endif
+	return -1;
+}
+
+static int cmd_fan_get(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	for (int i = 0; i < FAN_COUNT; i++) {
+		int rpm = fan_get_rpm(i);
+
+		if (rpm >= 0) {
+			shell_print(sh, "Fan %d: %d%% (%d RPM)", i,
+				    fan_duty[i], rpm);
+		} else {
+			shell_print(sh, "Fan %d: %d%%", i, fan_duty[i]);
+		}
+	}
+	return 0;
+}
+
+static int cmd_fan_set(const struct shell *sh, size_t argc, char **argv)
+{
+	if (argc < 3) {
+		shell_error(sh, "Usage: fan set <0|1> <0-100>");
+		return -EINVAL;
+	}
+
+	int fan_num = atoi(argv[1]);
+	int duty = atoi(argv[2]);
+
+	int ret = fan_set_duty(fan_num, duty);
+	if (ret < 0) {
+		shell_error(sh, "Failed to set fan: %d", ret);
+		return ret;
+	}
+
+	shell_print(sh, "Fan %d set to %d%%", fan_num, duty);
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_fan_cmds,
+	SHELL_CMD(get, NULL, "Get fan duty cycles", cmd_fan_get),
+	SHELL_CMD_ARG(set, NULL, "Set fan duty: <fan 0|1> <duty 0-100>",
+		      cmd_fan_set, 3, 0),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_CMD_REGISTER(fan, &sub_fan_cmds, "Fan control", NULL);
+
+int fan_init(void)
+{
+	for (int i = 0; i < FAN_COUNT; i++) {
+		if (!pwm_is_ready_dt(&fan_pwm[i])) {
+			LOG_ERR("Fan %d PWM device not ready", i);
+			return -ENODEV;
+		}
+	}
+
+	for (int i = 0; i < FAN_COUNT; i++) {
+		fan_set_duty(i, CONFIG_FAN_DEFAULT_DUTY_PCT);
+	}
+
+#ifdef HAS_FAN_TACH
+	for (int i = 0; i < FAN_COUNT; i++) {
+		if (!gpio_is_ready_dt(&fan_tach_gpio[i])) {
+			LOG_WRN("Fan %d tach GPIO not ready", i);
+			continue;
+		}
+		gpio_pin_configure_dt(&fan_tach_gpio[i], GPIO_INPUT);
+	}
+	k_work_schedule(&fan_tach_poll_work, K_MSEC(TACH_POLL_MS));
+	LOG_INF("Fan tachometer initialized (polling, %dms)", TACH_POLL_MS);
+#endif
+
+	LOG_INF("Fan control initialized (%d fans, default %d%%)",
+		FAN_COUNT, CONFIG_FAN_DEFAULT_DUTY_PCT);
+	return 0;
+}

--- a/src/fan.h
+++ b/src/fan.h
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: © 2026 Red Hat, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef __FAN_H__
+#define __FAN_H__
+
+#ifdef CONFIG_FAN_CONTROL
+int fan_init(void);
+int fan_set_duty(int fan_num, int duty_pct);
+int fan_get_duty(int fan_num);
+int fan_get_rpm(int fan_num);
+#else
+static inline int fan_init(void) { return 0; }
+static inline int fan_set_duty(int fan_num, int duty_pct) { return -1; }
+static inline int fan_get_duty(int fan_num) { return -1; }
+static inline int fan_get_rpm(int fan_num) { return -1; }
+#endif
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -26,6 +26,7 @@ LOG_MODULE_REGISTER(wallabmc, LOG_LEVEL_INF);
 #include "console_bridge_ws.h"
 #include "vpd.h"
 #include "git_sha.h"
+#include "fan.h"
 
 static bool boot_finished = false;
 
@@ -234,6 +235,12 @@ int main(void)
 	if (power_init() < 0) {
 		LOG_ERR("Power init failed");
 		return -1;
+	}
+
+	LOG_DBG("Fan init");
+	if (fan_init() < 0) {
+		LOG_ERR("Fan init failed");
+		/* Continue */
 	}
 
 	LOG_DBG("Reset init");

--- a/src/power.c
+++ b/src/power.c
@@ -16,10 +16,21 @@ LOG_MODULE_REGISTER(wallabmc_power);
 
 #include "config.h"
 
+/* Forward declarations */
+int power_reset(void);
+#ifdef CONFIG_SOM_PROTOCOL
+static void power_graceful_init(void);
+int power_graceful_off(void);
+#endif
+
 #define GPIO_POWER_1 DT_ALIAS(power_gpio_1)
 #define GPIO_POWER_2 DT_ALIAS(power_gpio_2)
 #define GPIO_RESET DT_ALIAS(reset_gpio_1)
 #define STATUS_LED DT_ALIAS(status_led)
+#define GPIO_POWER_GOOD DT_ALIAS(power_good)
+#define GPIO_POWER_LED  DT_ALIAS(power_led)
+#define GPIO_SLEEP_LED  DT_ALIAS(sleep_led)
+#define GPIO_POWER_BTN  DT_ALIAS(power_button)
 
 static const struct gpio_dt_spec power_gpios[] = {
 #if DT_NODE_HAS_STATUS_OKAY(GPIO_POWER_1)
@@ -29,6 +40,28 @@ static const struct gpio_dt_spec power_gpios[] = {
 	GPIO_DT_SPEC_GET(GPIO_POWER_2, gpios),
 #endif
 };
+
+#if DT_NODE_HAS_STATUS_OKAY(GPIO_POWER_GOOD)
+static const struct gpio_dt_spec power_good_gpio =
+	GPIO_DT_SPEC_GET(GPIO_POWER_GOOD, gpios);
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(GPIO_POWER_LED)
+static const struct gpio_dt_spec power_led_gpio =
+	GPIO_DT_SPEC_GET(GPIO_POWER_LED, gpios);
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(GPIO_SLEEP_LED)
+static const struct gpio_dt_spec sleep_led_gpio =
+	GPIO_DT_SPEC_GET(GPIO_SLEEP_LED, gpios);
+#endif
+
+static const struct gpio_dt_spec gpio_reset =
+#if DT_NODE_HAS_STATUS_OKAY(GPIO_RESET)
+	GPIO_DT_SPEC_GET(GPIO_RESET, gpios);
+#else
+	{ 0 };
+#endif
 
 static bool system_power_state = false;
 
@@ -44,10 +77,44 @@ static int power_on(void)
 	for (i = 0; i < ARRAY_SIZE(power_gpios); i++) {
 		ret = gpio_pin_set_dt(&power_gpios[i], 1);
 		if (ret < 0) {
-			LOG_INF("Could not toggle power GPIO %d\n", i);
+			LOG_ERR("Could not assert power GPIO %d", i);
 			return -1;
 		}
 	}
+
+#if DT_NODE_HAS_STATUS_OKAY(GPIO_POWER_GOOD)
+	int retries = CONFIG_POWER_GOOD_TIMEOUT_MS / CONFIG_POWER_GOOD_POLL_MS;
+
+	while (retries > 0) {
+		k_msleep(CONFIG_POWER_GOOD_POLL_MS);
+		if (gpio_pin_get_dt(&power_good_gpio) == 1) {
+			break;
+		}
+		retries--;
+	}
+
+	if (retries <= 0) {
+		LOG_ERR("Power-good timeout, aborting power on");
+		for (i = 0; i < ARRAY_SIZE(power_gpios); i++) {
+			gpio_pin_set_dt(&power_gpios[i], 0);
+		}
+		return -ETIMEDOUT;
+	}
+
+	LOG_INF("Power good detected");
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(GPIO_RESET)
+	gpio_pin_set_dt(&gpio_reset, 0);
+	LOG_INF("SOM reset released");
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(GPIO_POWER_LED)
+	gpio_pin_set_dt(&power_led_gpio, 1);
+#endif
+#if DT_NODE_HAS_STATUS_OKAY(GPIO_SLEEP_LED)
+	gpio_pin_set_dt(&sleep_led_gpio, 0);
+#endif
 
 	system_power_state = true;
 
@@ -58,10 +125,22 @@ static int power_off(void)
 {
 	int i, ret;
 
+#if DT_NODE_HAS_STATUS_OKAY(GPIO_RESET)
+	gpio_pin_set_dt(&gpio_reset, 1);
+	k_msleep(10);
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(GPIO_POWER_LED)
+	gpio_pin_set_dt(&power_led_gpio, 0);
+#endif
+#if DT_NODE_HAS_STATUS_OKAY(GPIO_SLEEP_LED)
+	gpio_pin_set_dt(&sleep_led_gpio, 1);
+#endif
+
 	for (i = 0; i < ARRAY_SIZE(power_gpios); i++) {
 		ret = gpio_pin_set_dt(&power_gpios[i], 0);
 		if (ret < 0) {
-			LOG_INF("Could not toggle power GPIO %d\n", i);
+			LOG_ERR("Could not deassert power GPIO %d", i);
 			return -1;
 		}
 	}
@@ -71,7 +150,7 @@ static int power_off(void)
 	return 0;
 }
 
-void power_set_state(bool on)
+int power_set_state(bool on)
 {
 	int ret;
 
@@ -82,11 +161,42 @@ void power_set_state(bool on)
 
 	if (ret < 0) {
 		LOG_ERR("Failed to set power state: %d", ret);
-		return;
+		return ret;
 	}
 
 	LOG_INF("System Power State changed to: %s", power_get_state() ? "ON" : "OFF");
+	return 0;
 }
+
+#if DT_NODE_HAS_STATUS_OKAY(GPIO_POWER_BTN)
+static const struct gpio_dt_spec power_btn_gpio =
+	GPIO_DT_SPEC_GET(GPIO_POWER_BTN, gpios);
+static struct gpio_callback power_btn_cb_data;
+
+static void power_btn_work_fn(struct k_work *work)
+{
+	if (power_get_state()) {
+#ifdef CONFIG_SOM_PROTOCOL
+		LOG_INF("Power button: graceful shutdown");
+		power_graceful_off();
+#else
+		LOG_INF("Power button: power off");
+		power_set_state(false);
+#endif
+	} else {
+		LOG_INF("Power button: power on");
+		power_set_state(true);
+	}
+}
+
+static K_WORK_DEFINE(power_btn_work, power_btn_work_fn);
+
+static void power_btn_isr(const struct device *dev,
+			   struct gpio_callback *cb, uint32_t pins)
+{
+	k_work_submit(&power_btn_work);
+}
+#endif
 
 int power_init(void)
 {
@@ -104,10 +214,51 @@ int power_init(void)
 		}
 	}
 
-	if (config_host_auto_poweron()) {
-		// Power on at BMC boot
-		return power_on();
+#if DT_NODE_HAS_STATUS_OKAY(GPIO_POWER_GOOD)
+	if (!gpio_is_ready_dt(&power_good_gpio)) {
+		LOG_ERR("Power-good GPIO not ready");
+		return -1;
 	}
+	if (gpio_pin_configure_dt(&power_good_gpio, GPIO_INPUT) < 0) {
+		LOG_ERR("Could not configure power-good GPIO");
+		return -1;
+	}
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(GPIO_POWER_LED)
+	if (gpio_is_ready_dt(&power_led_gpio)) {
+		gpio_pin_configure_dt(&power_led_gpio, GPIO_OUTPUT_INACTIVE);
+	}
+#endif
+#if DT_NODE_HAS_STATUS_OKAY(GPIO_SLEEP_LED)
+	if (gpio_is_ready_dt(&sleep_led_gpio)) {
+		gpio_pin_configure_dt(&sleep_led_gpio, GPIO_OUTPUT_ACTIVE);
+	}
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(GPIO_POWER_BTN)
+	if (gpio_is_ready_dt(&power_btn_gpio)) {
+		gpio_pin_configure_dt(&power_btn_gpio, GPIO_INPUT);
+		gpio_pin_interrupt_configure_dt(&power_btn_gpio,
+						GPIO_INT_EDGE_TO_ACTIVE);
+		gpio_init_callback(&power_btn_cb_data, power_btn_isr,
+				   BIT(power_btn_gpio.pin));
+		gpio_add_callback(power_btn_gpio.port, &power_btn_cb_data);
+		LOG_INF("Power button initialized");
+	}
+#endif
+
+	if (config_host_auto_poweron()) {
+		int ret = power_on();
+		if (ret < 0) {
+			LOG_ERR("Auto power-on failed: %d", ret);
+			return ret;
+		}
+	}
+
+#ifdef CONFIG_SOM_PROTOCOL
+	power_graceful_init();
+#endif
 
 	return 0;
 }
@@ -126,20 +277,114 @@ static int cmd_power_off(const struct shell *sh, size_t argc, char **argv)
 	return power_off();
 }
 
+#ifdef CONFIG_SOM_PROTOCOL
+static struct k_timer shutdown_timer;
+static struct k_timer reboot_timer;
+
+static void shutdown_timer_expiry(struct k_timer *timer)
+{
+	LOG_WRN("SOM shutdown timeout, forcing power off");
+	power_off();
+}
+
+static void reboot_timer_expiry(struct k_timer *timer)
+{
+	LOG_WRN("SOM reboot timeout, forcing reset");
+	power_reset();
+}
+
+static void som_power_notify(uint8_t cmd_type)
+{
+	if (cmd_type == SOM_CMD_POWER_OFF) {
+		k_timer_stop(&shutdown_timer);
+		LOG_INF("SOM acknowledged shutdown, powering off");
+		power_off();
+	} else if (cmd_type == SOM_CMD_RESTART) {
+		k_timer_stop(&reboot_timer);
+		LOG_INF("SOM acknowledged restart, resetting");
+		power_reset();
+	}
+}
+
+int power_graceful_off(void)
+{
+	int ret;
+
+	if (!power_get_state()) {
+		return 0;
+	}
+
+	ret = som_cmd(SOM_CMD_POWER_OFF, NULL, 0,
+		      CONFIG_SOM_PROTOCOL_TX_TIMEOUT_MS);
+	if (ret < 0) {
+		LOG_WRN("Could not send shutdown to SOM, forcing off");
+		return power_off();
+	}
+
+	k_timer_start(&shutdown_timer,
+		       K_MSEC(CONFIG_GRACEFUL_SHUTDOWN_TIMEOUT_MS), K_NO_WAIT);
+
+	LOG_INF("Graceful shutdown initiated, timeout %d ms",
+		CONFIG_GRACEFUL_SHUTDOWN_TIMEOUT_MS);
+	return 0;
+}
+
+int power_graceful_restart(void)
+{
+	int ret;
+
+	if (!power_get_state()) {
+		return power_on();
+	}
+
+	ret = som_cmd(SOM_CMD_RESTART, NULL, 0,
+		      CONFIG_SOM_PROTOCOL_TX_TIMEOUT_MS);
+	if (ret < 0) {
+		LOG_WRN("Could not send restart to SOM, forcing reset");
+		return power_reset();
+	}
+
+	k_timer_start(&reboot_timer,
+		       K_MSEC(CONFIG_GRACEFUL_REBOOT_TIMEOUT_MS), K_NO_WAIT);
+
+	LOG_INF("Graceful restart initiated, timeout %d ms",
+		CONFIG_GRACEFUL_REBOOT_TIMEOUT_MS);
+	return 0;
+}
+
+static void power_graceful_init(void)
+{
+	k_timer_init(&shutdown_timer, shutdown_timer_expiry, NULL);
+	k_timer_init(&reboot_timer, reboot_timer_expiry, NULL);
+	som_set_notify_callback(som_power_notify);
+}
+
+static int cmd_power_shutdown(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+	return power_graceful_off();
+}
+
+static int cmd_power_restart(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+	return power_graceful_restart();
+}
+#endif /* CONFIG_SOM_PROTOCOL */
+
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_power_cmds,
 	SHELL_CMD(on,    NULL, "Power on.", cmd_power_on),
-	SHELL_CMD(off,   NULL, "Power off.", cmd_power_off),
+	SHELL_CMD(off,   NULL, "Force power off.", cmd_power_off),
+#ifdef CONFIG_SOM_PROTOCOL
+	SHELL_CMD(shutdown, NULL, "Graceful shutdown (ask SOM first).", cmd_power_shutdown),
+	SHELL_CMD(restart, NULL, "Graceful restart (ask SOM first).", cmd_power_restart),
+#endif
 	SHELL_SUBCMD_SET_END
 );
 
 SHELL_CMD_REGISTER(power, &sub_power_cmds, "Power commands", NULL);
-
-static const struct gpio_dt_spec gpio_reset =
-#if DT_NODE_HAS_STATUS_OKAY(GPIO_RESET)
-	GPIO_DT_SPEC_GET(GPIO_RESET, gpios);
-#else
-	{ 0 };
-#endif
 
 int reset_init(void)
 {

--- a/src/power.h
+++ b/src/power.h
@@ -5,6 +5,8 @@
 #ifndef __POWER_H__
 #define __POWER_H__
 
+#include <errno.h>
+
 int power_init(void);
 int reset_init(void);
 int status_led_init(void);
@@ -12,5 +14,13 @@ int status_led_init(void);
 int power_set_state(bool on);
 bool power_get_state(void);
 int power_reset(void);
+
+#ifdef CONFIG_SOM_PROTOCOL
+int power_graceful_off(void);
+int power_graceful_restart(void);
+#else
+static inline int power_graceful_off(void) { return -ENOTSUP; }
+static inline int power_graceful_restart(void) { return -ENOTSUP; }
+#endif
 
 #endif

--- a/src/power_monitor.c
+++ b/src/power_monitor.c
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: © 2026 Red Hat, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/logging/log.h>
+
+#include "power.h"
+
+LOG_MODULE_REGISTER(power_monitor, LOG_LEVEL_INF);
+
+#define INA226_NODE DT_NODELABEL(ina226)
+
+#if DT_NODE_EXISTS(INA226_NODE)
+static const struct device *ina226_dev = DEVICE_DT_GET(INA226_NODE);
+
+int power_monitor_read(int32_t *voltage_mv, int32_t *current_ma,
+		       int32_t *power_mw)
+{
+	struct sensor_value val;
+	int ret;
+
+	if (!power_get_state()) {
+		return -ENODEV;
+	}
+
+	if (!device_is_ready(ina226_dev)) {
+		ina226_dev->state->initialized = false;
+		ret = device_init(ina226_dev);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	ret = sensor_sample_fetch(ina226_dev);
+	if (ret < 0) {
+		LOG_ERR("INA226 sample fetch failed: %d", ret);
+		return ret;
+	}
+
+	ret = sensor_channel_get(ina226_dev, SENSOR_CHAN_VOLTAGE, &val);
+	if (ret == 0 && voltage_mv) {
+		*voltage_mv = val.val1 * 1000 + val.val2 / 1000;
+	}
+
+	ret = sensor_channel_get(ina226_dev, SENSOR_CHAN_CURRENT, &val);
+	if (ret == 0 && current_ma) {
+		*current_ma = val.val1 * 1000 + val.val2 / 1000;
+	}
+
+	ret = sensor_channel_get(ina226_dev, SENSOR_CHAN_POWER, &val);
+	if (ret == 0 && power_mw) {
+		*power_mw = val.val1 * 1000 + val.val2 / 1000;
+	}
+
+	return 0;
+}
+
+static int cmd_power_info(const struct shell *sh, size_t argc, char **argv)
+{
+	int32_t voltage_mv, current_ma, power_mw;
+	int ret;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	ret = power_monitor_read(&voltage_mv, &current_ma, &power_mw);
+	if (ret == -ENODEV) {
+		shell_error(sh, "Power monitor unavailable (host power off)");
+		return ret;
+	}
+	if (ret < 0) {
+		shell_error(sh, "Failed to read power monitor: %d", ret);
+		return ret;
+	}
+
+	shell_print(sh, "12V Rail:");
+	shell_print(sh, "  Voltage: %d.%03d V", voltage_mv / 1000,
+		    voltage_mv % 1000);
+	shell_print(sh, "  Current: %d.%03d A", current_ma / 1000,
+		    current_ma % 1000);
+	shell_print(sh, "  Power:   %d.%03d W", power_mw / 1000,
+		    power_mw % 1000);
+
+	return 0;
+}
+
+SHELL_CMD_REGISTER(power_info, NULL, "Show 12V rail power (INA226)",
+		   cmd_power_info);
+
+#endif /* DT_NODE_EXISTS(INA226_NODE) */

--- a/src/power_monitor.h
+++ b/src/power_monitor.h
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: © 2026 Red Hat, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef __POWER_MONITOR_H__
+#define __POWER_MONITOR_H__
+
+#ifdef CONFIG_POWER_MONITOR
+int power_monitor_read(int32_t *voltage_mv, int32_t *current_ma,
+		       int32_t *power_mw);
+#else
+static inline int power_monitor_read(int32_t *v, int32_t *c, int32_t *p)
+{
+	*v = 0; *c = 0; *p = 0;
+	return -ENOTSUP;
+}
+#endif
+
+#endif


### PR DESCRIPTION
Generic hardware modules for BMC board support:

Fan control (src/fan.c):
- PWM speed control (0-100% duty cycle)
- Tachometer RPM via GPIO polling (immune to PWM crosstalk)
- Shell: fan get, fan set

Power monitor (src/power_monitor.c):
- INA226 voltage/current/power via Zephyr sensor API
- Gated on host power state to suppress I2C errors when host is off
- Shell: power_info

Power management improvements (src/power.c):
- Power-good GPIO with configurable timeout
- Front panel power button (GPIO interrupt, work queue debounced)
- Power/sleep LED indicators
- Auto power-on error propagation
- Reset hold time increased to 10 seconds with user feedback

Stubs in headers for conditional compilation.  Boards without these peripherals link cleanly.