### PR TITLE
feat: P550 board definition, OpenOCD config, hardware docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+build/
+build-*/
+build-*.hex
+*.signed.hex
+host/somd/somd
+host/somd/test_protocol
+boards/sifive/hifive_premier_p550_mcu/host-somd/somd
+boards/sifive/hifive_premier_p550_mcu/host-somd/test_protocol

--- a/boards/hifive_premier_p550_mcu.conf
+++ b/boards/hifive_premier_p550_mcu.conf
@@ -1,4 +1,6 @@
 CONFIG_APP_HTTPS=n
+CONFIG_EEPROM=y
+CONFIG_SENSOR=y
 
 # Redfish system overview (board-specific)
 CONFIG_REDFISH_SYSTEM_PRODUCT_NAME="HiFive Premier P550"

--- a/boards/hifive_premier_p550_mcu.overlay
+++ b/boards/hifive_premier_p550_mcu.overlay
@@ -36,15 +36,32 @@
         power-gpio-1 = &dcen;
         power-gpio-2 = &atxpson;
         status-led = &blue_led;
+        reset-gpio = &som_reset;
+        power-good = &pwrok;
+        power-button = &power_button;
+        power-led = &pwr_led;
+        sleep-led = &slp_led;
 
-	host-console-uart = &usart6;
-	host-console-uart-muxsel = &uartmuxsel;
+        fan-tach-0 = &fan_tach0;
+        fan-tach-1 = &fan_tach1;
+
+        host-console-uart = &usart6;
+        host-console-uart-muxsel = &uartmuxsel;
+        reset-button = &user_button_recovery;
+
+        bootsel-0 = &bootsel0;
+        bootsel-1 = &bootsel1;
+        bootsel-2 = &bootsel2;
+        bootsel-3 = &bootsel3;
+
+        i2c-mux-en = &i2c_mux_en;
+        eeprom-wp = &eeprom_wp;
     };
 
 };
 
 &spi4 {
-     status = "disabled";
+    status = "disabled";
 };
 
 &rng {
@@ -52,27 +69,27 @@
 };
 
 &flash0 {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
+    partitions {
+        compatible = "fixed-partitions";
+        #address-cells = <1>;
+        #size-cells = <1>;
 
-		/* Sectors 0-1 (2*16 kbytes) for mcuboot */
-                boot_partition: partition@0 {
-                        label = "mcuboot";
-                        reg = <0x00000000 DT_SIZE_K(32)>;
-                };
+        /* Sectors 0-1 (2*16 kbytes) for mcuboot */
+        boot_partition: partition@0 {
+            label = "mcuboot";
+            reg = <0x00000000 DT_SIZE_K(32)>;
+        };
 
-		/* 2-3 (2*16 kbytes) for app storage, enough for NVS storage */
-                storage_partition: partition@8000 {
-                        label = "storage";
-                        reg = <0x00008000 DT_SIZE_K(32)>;
-                };
+        /* 2-3 (2*16 kbytes) for app storage, enough for NVS storage */
+        storage_partition: partition@8000 {
+            label = "storage";
+            reg = <0x00008000 DT_SIZE_K(32)>;
+        };
 
-		/* 4-7 (64 + 3*128 kbytes) are for the application image */
-                slot0_partition: partition@10000 {
-                        label = "image-0";
-                        reg = <0x00010000 DT_SIZE_K(448)>;
-                };
-	};
+        /* 4-7 (64 + 3*128 kbytes) are for the application image */
+        slot0_partition: partition@10000 {
+            label = "image-0";
+            reg = <0x00010000 DT_SIZE_K(448)>;
+        };
+    };
 };

--- a/boards/sifive/hifive_premier_p550_mcu/doc/hardware.rst
+++ b/boards/sifive/hifive_premier_p550_mcu/doc/hardware.rst
@@ -86,7 +86,7 @@ Currently implemented in WallaBMC
    * - PC10/PC11
      - UART4 TX/RX
      - ``uart4``
-     - Connected to SoC UART2 (enabled in DTS, unused by code)
+     - Connected to SoC UART2. BMC-SoC protocol (som_protocol.c). Host-side daemon: host-somd/
    * - PE0
      - JTAG TCK
      - ``jtagtck``
@@ -124,145 +124,76 @@ Currently implemented in WallaBMC
      - (part of mac)
      - Ethernet PHY reset. Active LOW.
 
-NOT yet implemented (features to add)
---------------------------------------
-
-SOM reset control (PD5 output, PD6 input)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Also implemented in WallaBMC
+------------------------------
 
 .. list-table::
    :header-rows: 1
 
    * - STM32 Pin
-     - Signal (from schematic)
-     - Direction
-     - Active
+     - Signal
+     - DTS node / alias
      - Description
-   * - **PD5**
+   * - PD5
      - SOM WARM RESET
-     - Output
-     - LOW
-     - Drives SOM warm reset. Active-low: assert (drive low) to reset, deassert (drive high or float) to release.
-   * - **PD6**
+     - ``som_reset`` / ``reset-gpio-1``
+     - SOM warm reset. Assert during power-off, release after power-good.
+   * - PD6
      - SOM RESET OUT DETECT
-     - Input
-     - LOW
-     - SOM reset status feedback. Goes low when SOM is in reset. Can be used to confirm reset completed or detect SoC-initiated resets.
-
-**Implementation**: Add ``reset-gpio`` alias in the overlay pointing to a new
-GPIO node for PD5 (active-low). The existing ``power_reset()`` in ``power.c``
-already supports this alias and will pulse it for 1 second. PD6 could
-optionally be used to confirm reset state or detect SoC-initiated resets.
-
-.. code-block:: dts
-
-   /* In the DTS gpio_keys node: */
-   som_reset: som_reset {
-       gpios = <&gpiod 5 GPIO_ACTIVE_LOW>;
-       label = "SOM_RESET";
-   };
-   som_rst_detect: som_rst_detect {
-       gpios = <&gpiod 6 GPIO_ACTIVE_LOW>;
-       label = "SOM_RST_DETECT";
-   };
-
-   /* In the overlay aliases: */
-   reset-gpio = &som_reset;
-
-Power-good monitoring (PE5)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. list-table::
-   :header-rows: 1
-
-   * - STM32 Pin
-     - Signal (from schematic)
-     - Direction
-     - Active
-     - Description
-   * - **PE5**
+     - ``som_rst_detect``
+     - SOM reset feedback input (defined, not yet used in code).
+   * - PE5
      - BUCK POWER GOOD DETECTION
-     - Input
-     - HIGH
-     - Combined power-good from VDD_5V_SOM_PG and VDD_5V_SYS_PG buck converters. HIGH = power rails stable.
-
-**Implementation**: Add a GPIO input node. Use it to:
-
-#. Confirm power-on completed successfully after asserting DC_EN + ATX_PS_ON
-#. Detect unexpected power loss (interrupt on falling edge)
-#. Report true hardware power status via Redfish and shell (instead of just
-   tracking the software-requested state)
-
-.. code-block:: dts
-
-   pwrok: pwrok {
-       gpios = <&gpioe 5 GPIO_ACTIVE_HIGH>;
-       label = "DCDC_PWR_OK";
-   };
-
-Power button input (PA12)
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. list-table::
-   :header-rows: 1
-
-   * - STM32 Pin
-     - Signal (from schematic)
-     - Direction
-     - Active
-     - Description
-   * - **PA12**
+     - ``pwrok`` / ``power-good``
+     - DC power good input. Polled during power-on with configurable timeout.
+   * - PA12
      - POWER ON KEY
-     - Input
-     - LOW
-     - Front-panel power button press detection. Active-low.
+     - ``power_button`` / ``power-button``
+     - Front-panel power button. Toggles power state on press (graceful shutdown if SOM protocol available).
+   * - PD0-PD3
+     - SOM BOOT MODE CTRL 0-3
+     - ``bootsel0``-``bootsel3`` / ``bootsel-0``-``bootsel-3``
+     - Boot source selection. Hardware mode (follow DIP switch) or software mode (MCU drives).
+   * - PD12/PD13
+     - TIM4 CH1/CH2 PWM
+     - ``fan0``/``fan1`` (via ``pwm4``)
+     - Fan PWM speed control (25 kHz). Shell: ``fan set <0|1> <0-100>``.
+   * - PD10
+     - POWER LED
+     - ``pwr_led`` / ``power-led``
+     - Front-panel power LED. On when host power is on.
+   * - PD11
+     - SLEEP LED
+     - ``slp_led`` / ``sleep-led``
+     - Front-panel sleep LED. On when host power is off (standby).
+   * - PA3
+     - I2C_MUX_EN
+     - ``i2c_mux_en`` / ``i2c-mux-en``
+     - TMUX1574 mux control. Enabled before EEPROM access.
+   * - PC8
+     - EEPROM WRITE PROTECT
+     - ``eeprom_wp`` / ``eeprom-wp``
+     - EEPROM write-protect control.
+   * - PB6/PB7
+     - I2C1 SCL/SDA
+     - ``&i2c1``
+     - AT24C02C EEPROM (carrier board identity, MACs). Deferred init.
+   * - PA8/PC9
+     - I2C3 SCL/SDA
+     - ``&i2c3``
+     - INA226 power monitor (12V rail). Deferred init.
 
-**Implementation**: This is distinct from the recovery button (PB1). It allows
-the BMC to detect a physical power button press and trigger power on/off of the
-host. Add as a gpio-key with interrupt support and connect to the power
-on/off logic. Consider toggle behavior (press = power on if off, power off if
-on) and configurable long-press for force-off.
+Hardware reference
+===================
 
-.. code-block:: dts
+EIC7700X boot modes (PD0-PD3)
+------------------------------
 
-   power_button: power_button {
-       gpios = <&gpioa 12 GPIO_ACTIVE_LOW>;
-       label = "POWER_BUTTON";
-   };
+Implemented in ``bootsel.c``. Shell: ``bootsel get``, ``bootsel set <0-15|hw>``.
 
-SOM boot mode selection (PD0, PD1, PD2, PD3)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. list-table::
-   :header-rows: 1
-
-   * - STM32 Pin
-     - Signal (from schematic)
-     - Direction
-     - Description
-   * - **PD0**
-     - SOM BOOT MODE CTRL 0 (BOOT_SEL0)
-     - In/Out
-     - SoC boot source bit 0
-   * - **PD1**
-     - SOM BOOT MODE CTRL 1 (BOOT_SEL1)
-     - In/Out
-     - SoC boot source bit 1
-   * - **PD2**
-     - SOM BOOT MODE CTRL 2 (BOOT_SEL2)
-     - In/Out
-     - SoC boot source bit 2
-   * - **PD3**
-     - SOM BOOT MODE CTRL 3 (BOOT_SEL3)
-     - In/Out
-     - SoC boot source bit 3
-
-These control the EIC7700X SoC boot source. The schematic labels them as
-INOUT with "USER DEFINE" active level, meaning they share control with the
-on-board DIP switch (SW1). The MCU must set its pins to high-impedance
-(input mode) if the DIP switch is being used manually.
-
-**Boot modes** (from EIC7700X documentation):
+The MCU drives BOOT_SEL[3:0] (PD0-PD3) to select the SoC boot source.
+In hardware mode, pins are high-impedance inputs following the DIP switch (SW1).
+In software mode, the MCU drives the pins as outputs.
 
 When OTP security bit = 1 (only lower 2 bits matter):
 
@@ -348,153 +279,50 @@ When OTP security bit = 0 (all 4 bits used):
      - SPI NOR
      - USB
 
-**Implementation**: Add GPIO output nodes for each pin. Implement a ``boot``
-shell command that allows selecting the SoC boot source before power-on or
-reset. Store the selected boot mode in persistent config. Default to
-high-impedance (follow DIP switch) unless explicitly overridden.
+I2C bus architecture
+---------------------
 
-Fan control (PD12, PD13 PWM outputs; PE6, PB14 tachometer inputs)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. list-table::
-   :header-rows: 1
-
-   * - STM32 Pin
-     - Signal (from schematic)
-     - Direction
-     - Description
-   * - **PD12**
-     - MCU TIMER4 PWM1 (TIM4_CH1)
-     - Output
-     - CPU/SOM fan PWM speed control
-   * - **PD13**
-     - MCU TIMER4 PWM2 (TIM4_CH2)
-     - Output
-     - Chassis fan PWM speed control
-   * - **PE6**
-     - CHASS FAN TACH1
-     - Input
-     - Chassis fan 1 tachometer (RPM sensing)
-   * - **PB14**
-     - CHASS FAN TACH2
-     - Input
-     - Chassis fan 2 tachometer (RPM sensing)
-
-Note: The schematic also shows TIM4_CH3 (PD14) and TIM4_CH4 (PD15) on the
-STM32 pinout, but only CH1 and CH2 are listed in the MCU IO function table.
-
-Both PWM outputs use Timer 4 (TIM4). The tachometer inputs typically provide
-two pulses per revolution for standard PC fans.
-
-**Implementation**: Use Zephyr's PWM driver for TIM4 channels 1 and 2. Use
-GPIO interrupt (rising edge) or timer input capture for tachometer inputs.
-Expose fan speed via Redfish ``Thermal`` resource and a ``fan`` shell command.
-
-.. code-block:: dts
-
-   &timers4 {
-       status = "okay";
-       pwm4: pwm {
-           status = "okay";
-           pinctrl-0 = <&tim4_ch1_pd12 &tim4_ch2_pd13>;
-           pinctrl-names = "default";
-       };
-   };
-
-I2C buses (I2C1: PB6/PB7, I2C3: PA8/PC9)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-**I2C3** (PA8 SCL, PC9 SDA, PA9 SMBA) - carrier board peripherals:
+**I2C3** (PA8 SCL, PC9 SDA) — dedicated to carrier board peripherals:
 
 .. list-table::
    :header-rows: 1
 
    * - Device
      - Address
-     - I/O Voltage
      - Description
    * - INA226 power monitor
-     - 0x44 (1000100)
-     - 3.3V
-     - 12V input rail power monitor. Measures voltage and current. SMBus alert on PA9 (MCU_I2C3_SMBA) for over-current/over-voltage notification.
+     - 0x44
+     - 12V input rail. Implemented in ``power_monitor.c`` (deferred init).
 
-**I2C1** (PB6 SCL, PB7 SDA) - shared bus:
+**I2C1** (PB6 SCL, PB7 SDA) — shared bus (MCU / SoC / FT4232H):
 
 .. list-table::
    :header-rows: 1
 
    * - Device
      - Address
-     - I/O Voltage
      - Description
    * - AT24C02C EEPROM
-     - 0x50 (1010000)
-     - 1.8V
-     - 2 Kbit EEPROM. Stores carrier board information (serial number, MAC, manufacturing data). Write-protect controlled by PC8 (EEPROM_WP, active LOW per schematic).
+     - 0x50
+     - Carrier board identity (serial, MACs). Implemented in ``board_identity.c`` (deferred init, vendor CRC32).
 
-The schematic notes (page 3 ADDRESS MAP):
+The I2C1 bus is shared via a TMUX1574 mux (U77). PA3 (I2C_MUX_EN) must be
+driven to route the bus to the MCU before EEPROM access. PC8 (EEPROM_WP)
+controls write-protect (HIGH = protected).
 
-   "SOM, FT4232 and BMC MCU share I2C BUS"
+Fan control reference
+----------------------
 
-This means I2C1 is shared between the MCU, the SoC (I2C10), and the FT4232H
-(via BCBUS4/BCBUS5). Bus arbitration is controlled by a TMUX1574 mux (U77).
+PWM implemented in ``fan.c``. Shell: ``fan get``, ``fan set <0|1> <0-100>``.
 
-**Related control GPIOs**:
+PD12 (TIM4_CH1) drives the SOM fan, PD13 (TIM4_CH2) drives the chassis fan.
+25 kHz PWM, 0-100% duty cycle.
 
-.. list-table::
-   :header-rows: 1
+Tachometer inputs PE6 (CHASS_FAN_TACH1) and PB14 (CHASS_FAN_TACH2) are
+defined in the schematic but not yet implemented in code.
 
-   * - STM32 Pin
-     - Signal (from schematic)
-     - Direction
-     - Active
-     - Description
-   * - **PA3**
-     - I2C_MUX_EN
-     - Output
-     - \-
-     - Enable TMUX1574 mux (U77) for I2C bus routing. Controls whether SoC or MCU owns the shared I2C1 bus.
-   * - **PC8**
-     - EEPROM WRITE PROTECT
-     - Output
-     - HIGH
-     - EEPROM write-protect control. HIGH = protected, LOW = writable. (Confirmed: original firmware ``eepromwp-s 0`` writes PC8=LOW="disabled", ``eepromwp-s 1`` writes PC8=HIGH="enabled".)
-
-**Implementation**: Enable I2C1 and I2C3 in device tree. Implement:
-
-#. INA226 driver for 12V rail monitoring (voltage, current, power). Zephyr has
-   an upstream ``ti,ina226`` sensor driver. Expose via Redfish ``Power`` resource.
-#. EEPROM read/write for board identity data (serial number, MAC, etc.)
-#. I2C mux control (PA3) to arbitrate bus access with SoC. Set mux to MCU
-   before I2C1 operations, release after.
-
-.. code-block:: dts
-
-   &i2c1 {
-       pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
-       pinctrl-names = "default";
-       status = "okay";
-       clock-frequency = <I2C_BITRATE_STANDARD>;
-
-       eeprom: eeprom@50 {
-           compatible = "atmel,at24";
-           reg = <0x50>;
-           size = <256>;
-       };
-   };
-
-   &i2c3 {
-       pinctrl-0 = <&i2c3_scl_pa8 &i2c3_sda_pc9>;
-       pinctrl-names = "default";
-       status = "okay";
-       clock-frequency = <I2C_BITRATE_STANDARD>;
-
-       ina226: ina226@44 {
-           compatible = "ti,ina226";
-           reg = <0x44>;
-           rshunt-micro-ohms = <1000>; /* 1 mOhm shunt resistor */
-       };
-   };
+NOT yet implemented
+--------------------
 
 SPI to SoC (SPI2: PB9, PB10, PC2, PC3)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -560,44 +388,6 @@ The W25Q32 (32 Mbit / 4 MB SPI flash) footprint exists on the carrier board
 but is **not mounted** by default. If populated, could provide additional
 storage for BMC firmware, logs, or configuration beyond the 512 KB internal
 flash.
-
-Front panel LEDs (PD10, PD11)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. list-table::
-   :header-rows: 1
-
-   * - STM32 Pin
-     - Signal (from schematic)
-     - Direction
-     - Active
-     - Description
-   * - **PD10**
-     - POWER LED
-     - Output
-     - HIGH
-     - Front-panel power LED indicator
-   * - **PD11**
-     - SLEEP LED
-     - Output
-     - HIGH
-     - Front-panel sleep/standby LED indicator
-
-**Implementation**: Add as LED nodes in DTS. Drive PWR_LED on when host power
-is on (track ``power_get_state()``), SLP_LED when host is powered off but BMC is
-running (standby indicator).
-
-.. code-block:: dts
-
-   /* Add to the leds node in DTS: */
-   pwr_led: pwr_led {
-       gpios = <&gpiod 10 GPIO_ACTIVE_HIGH>;
-       label = "Power LED";
-   };
-   slp_led: slp_led {
-       gpios = <&gpiod 11 GPIO_ACTIVE_HIGH>;
-       label = "Sleep LED";
-   };
 
 Other/misc GPIO (PE15)
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -743,22 +533,6 @@ Known bugs in current DTS/overlay
    a separate TMUX1574 mux (U70) to the FT4232H channel A. It is unclear
    whether the MCU bit-bang path connects to the same JTAG chain or is a
    separate debug interface. Hardware verification needed.
-
-Feature implementation priority
-================================
-
-Recommended order based on impact and complexity:
-
-#. **Fix reset-button alias** - one-line DTS fix, enables config-clear button
-#. **SOM reset** (PD5) - add DTS node + alias, existing ``power_reset()`` handles it
-#. **Power-good monitoring** (PE5) - add GPIO input, confirm power state
-#. **Front panel LEDs** (PD10/PD11) - simple GPIO output, track power state
-#. **Power button** (PA12) - GPIO interrupt, triggers power on/off
-#. **I2C3 + INA226** - 12V rail power monitoring, Redfish Power resource
-#. **Fan control** (TIM4 PWM + tachometers) - requires PWM driver, new module
-#. **Boot mode select** (PD0-PD3) - new shell command, persistent config
-#. **I2C1 + EEPROM** - board identity, MAC address storage
-#. **SPI2 to SoC** - MCU-SoC communication channel (lower priority)
 
 Carrier board EEPROM (AT24C02C on I2C1)
 =========================================
@@ -988,7 +762,8 @@ Packet format (267 bytes, 0x10B)
      - ``BA BD BA BD``
 
 Both request and response use the same 267-byte frame format. The SoC runs a
-matching daemon that receives on its UART0 and responds in the same format.
+matching daemon that receives on its UART2 and responds in the same format.
+See ``host-somd/`` for WallaBMC's implementation of this daemon.
 
 Message types
 --------------

--- a/boards/sifive/hifive_premier_p550_mcu/hifive_premier_p550_mcu.dts
+++ b/boards/sifive/hifive_premier_p550_mcu/hifive_premier_p550_mcu.dts
@@ -7,6 +7,7 @@
 #include <st/f4/stm32f407Xe.dtsi>
 #include <st/f4/stm32f407v(e-g)tx-pinctrl.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	model = "SiFive HiFive Premier P550 MCU";
@@ -63,8 +64,78 @@
 			gpios = <&gpiob 15 GPIO_ACTIVE_HIGH>;
 			label = "UARTMUXSEL";
 		};
+		pwrok: pwrok {
+			gpios = <&gpioe 5 GPIO_ACTIVE_HIGH>;
+			label = "DCDC_PWR_OK";
+		};
+		som_reset: som_reset {
+			gpios = <&gpiod 5 GPIO_ACTIVE_LOW>;
+			label = "SOM_RESET";
+		};
+		som_rst_detect: som_rst_detect {
+			gpios = <&gpiod 6 GPIO_ACTIVE_LOW>;
+			label = "SOM_RST_DETECT";
+		};
+		power_button: power_button {
+			gpios = <&gpioa 12 GPIO_ACTIVE_LOW>;
+			label = "POWER_BUTTON";
+		};
+		pwr_led: pwr_led_key {
+			gpios = <&gpiod 10 GPIO_ACTIVE_HIGH>;
+			label = "POWER_LED";
+		};
+		slp_led: slp_led_key {
+			gpios = <&gpiod 11 GPIO_ACTIVE_HIGH>;
+			label = "SLEEP_LED";
+		};
+		bootsel0: bootsel0 {
+			gpios = <&gpiod 0 GPIO_ACTIVE_HIGH>;
+			label = "BOOT_SEL0";
+		};
+		bootsel1: bootsel1 {
+			gpios = <&gpiod 1 GPIO_ACTIVE_HIGH>;
+			label = "BOOT_SEL1";
+		};
+		bootsel2: bootsel2 {
+			gpios = <&gpiod 2 GPIO_ACTIVE_HIGH>;
+			label = "BOOT_SEL2";
+		};
+		bootsel3: bootsel3 {
+			gpios = <&gpiod 3 GPIO_ACTIVE_HIGH>;
+			label = "BOOT_SEL3";
+		};
+		fan_tach0: fan_tach0 {
+			gpios = <&gpioe 6 GPIO_ACTIVE_HIGH>;
+			label = "FAN_TACH0";
+		};
+		fan_tach1: fan_tach1 {
+			gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
+			label = "FAN_TACH1";
+		};
+		i2c_mux_en: i2c_mux_en {
+			gpios = <&gpioa 3 GPIO_ACTIVE_HIGH>;
+			label = "I2C_MUX_EN";
+		};
+		eeprom_wp: eeprom_wp {
+			gpios = <&gpioc 8 GPIO_ACTIVE_HIGH>;
+			label = "EEPROM_WP";
+		};
 	};
 
+
+	fans {
+		compatible = "pwm-leds";
+
+		fan0: fan_0 {
+			pwms = <&pwm4 1 40000 PWM_POLARITY_INVERTED>;
+			label = "Fan 0";
+		};
+
+		fan1: fan_1 {
+			pwms = <&pwm4 2 40000 PWM_POLARITY_INVERTED>;
+			label = "Fan 1";
+		};
+	};
 
 	aliases {
 		led0 = &red_led;
@@ -74,6 +145,7 @@
 		boot1 = &boot1;
 		dcen = &dcen;
 		atxpson = &atxpson;
+		reset-gpio-1 = &som_reset;
 	};
 };
 
@@ -160,5 +232,46 @@
 	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		reg = <0x00>;
+	};
+};
+
+&i2c1 {
+	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
+	pinctrl-names = "default";
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+
+	eeprom: eeprom@50 {
+		compatible = "atmel,at24";
+		reg = <0x50>;
+		size = <256>;
+		pagesize = <8>;
+		address-width = <8>;
+		timeout = <5>;
+		zephyr,deferred-init;
+	};
+};
+
+&timers4 {
+	status = "okay";
+	pwm4: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim4_ch1_pd12 &tim4_ch2_pd13>;
+		pinctrl-names = "default";
+	};
+};
+
+&i2c3 {
+	pinctrl-0 = <&i2c3_scl_pa8 &i2c3_sda_pc9>;
+	pinctrl-names = "default";
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+
+	ina226: ina226@44 {
+		compatible = "ti,ina226";
+		reg = <0x44>;
+		rshunt-micro-ohms = <1000>;
+		current-lsb-microamps = <1000>;
+		zephyr,deferred-init;
 	};
 };

--- a/boards/sifive/hifive_premier_p550_mcu/hifive_premier_p550_mcu_defconfig
+++ b/boards/sifive/hifive_premier_p550_mcu/hifive_premier_p550_mcu_defconfig
@@ -16,3 +16,9 @@ CONFIG_UART_CONSOLE=y
 
 # Enable GPIO
 CONFIG_GPIO=y
+
+# Enable I2C
+CONFIG_I2C=y
+
+# Enable PWM
+CONFIG_PWM=y

--- a/boards/sifive/hifive_premier_p550_mcu/support/README.md
+++ b/boards/sifive/hifive_premier_p550_mcu/support/README.md
@@ -1,31 +1,123 @@
-# Quick installation
+# HiFive Premier P550 Debug & Flashing
 
-SiFive made an openocd cfg public [here](https://github.com/sifiveinc/hifive-premier-p550-tools/blob/master/mcu-firmware/stm32_openocd.cfg)
+The P550 debug USB-C port exposes an FTDI FT4232H with four channels:
+
+| Channel | Interface | Linux | macOS | Function |
+|---------|-----------|-------|-------|----------|
+| if00 | SoC JTAG | `/dev/ttyUSB0` | `/dev/tty.usbserial-*00` | EIC7700X RISC-V debug |
+| if01 | BMC JTAG | `/dev/ttyUSB1` | `/dev/tty.usbserial-*01` | STM32F407 flash/debug |
+| if02 | SoC UART | `/dev/ttyUSB2` | `/dev/tty.usbserial-*02` | Host serial console (115200 8N1) |
+| if03 | BMC UART | `/dev/ttyUSB3` | `/dev/tty.usbserial-*03` | Zephyr shell (115200 8N1) |
+
+## OpenOCD Configuration
+
+`p550_openocd.cfg` supports two targets via a `TARGET` variable:
+
+- **`bmc`** (default) — STM32F407 on FTDI channel 1
+- **`soc`** — EIC7700X RISC-V on FTDI channel 0
+
+The target defaults to `bmc` if not specified.
+
+## Prerequisites
+
+```bash
+# macOS
+brew install open-ocd
+
+# Fedora
+sudo dnf install openocd gdb
+
+# Ubuntu/Debian
+sudo apt-get install openocd gdb-multiarch
 ```
-wget https://raw.githubusercontent.com/sifiveinc/hifive-premier-p550-tools/refs/heads/master/mcu-firmware/stm32_openocd.cfg
+
+## Flash BMC firmware
+
+From a local build:
+
+```bash
+openocd -f boards/sifive/hifive_premier_p550_mcu/support/p550_openocd.cfg \
+  -c "init; halt; \
+      program build/mcuboot/zephyr/zephyr.hex verify; \
+      program build/wallabmc/zephyr/zephyr.signed.hex verify; \
+      reset; exit"
 ```
 
-Connect a USB-C cable to the P550 debug port.
+From CI artifacts (after extracting the firmware zip):
 
-You can download the WallaBMC p550 images from a successful github actions run from [here](https://github.com/tenstorrent/wallabmc/actions).
-Look for the `wallabmc-firmware-hifive_premier_p550_mcu` artifact (github doesn't provide a static link). Unzip this and do:
-```
-openocd -f stm32_openocd.cfg -c 'init; halt; flash write_image erase mcuboot.hex ; flash write_image erase wallabmc.signed.hex ; reset; exit'
-```
-
-This should flash and then restart the BMC. You should then see output on the USB UART. (_NOTE: There are two UARTS on the USB. One for the host p550 and one for the STM32_)
-
-If you are building yourself with west, follow the build instructions from the [README](../README.md) and then flash with:
-```
-openocd -f stm32_openocd.cfg -c 'init; halt; flash write_image erase build/mcuboot/zephyr/zephyr.hex ; flash write_image erase build/wallabmc/zephyr/zephyr.signed.hex ; reset; exit'
+```bash
+openocd -f boards/sifive/hifive_premier_p550_mcu/support/p550_openocd.cfg \
+  -c "init; halt; \
+      program zephyr.hex verify; \
+      program zephyr.signed.hex verify; \
+      reset; exit"
 ```
 
-# Flash standard firmware from SiFive
+## Debug the RISC-V SoC
 
-If you want to go back to the original firmware, do this:
+Start OpenOCD targeting the SoC (4 P550 cores):
 
+```bash
+openocd -c 'set TARGET soc' \
+  -f boards/sifive/hifive_premier_p550_mcu/support/p550_openocd.cfg
 ```
-wget https://raw.githubusercontent.com/sifiveinc/hifive-premier-p550-tools/refs/heads/master/mcu-firmware/stm32_openocd.cfg
-wget https://raw.githubusercontent.com/sifiveinc/hifive-premier-p550-tools/refs/heads/master/mcu-firmware/STM32F407VET6_BMC.elf
-openocd -f stm32_openocd.cfg -c 'init; halt; program STM32F407VET6_BMC.elf; reset; exit'
+
+In a separate terminal, connect GDB:
+
+```bash
+gdb
+(gdb) target extended-remote localhost:3333
+(gdb) info threads       # List all 4 harts
+(gdb) monitor reset halt # Reset and halt
+(gdb) x/4i $pc           # Disassemble at PC
+```
+
+For source-level kernel debugging, point GDB at the debuginfo tree:
+
+```gdb
+(gdb) set debug-file-directory /path/to/debuginfo/usr/lib/debug
+(gdb) set sysroot /path/to/debuginfo
+```
+
+## Serial Console
+
+Monitor the host boot or interact with the BMC shell:
+
+```bash
+# Host serial console (SoC UART, channel C)
+picocom -b 115200 /dev/ttyUSB2       # Linux
+screen /dev/tty.usbserial-*02 115200  # macOS
+
+# BMC shell (MCU UART, channel D)
+picocom -b 115200 /dev/ttyUSB3       # Linux
+screen /dev/tty.usbserial-*03 115200  # macOS
+```
+
+## Troubleshooting
+
+**BMC won't halt (DAP WAIT stalls):**
+
+The flash may be read-protected. Unlock it first (erases all flash):
+
+```bash
+sudo openocd -f boards/sifive/hifive_premier_p550_mcu/support/p550_openocd.cfg \
+  -c "init; halt; stm32f4x unlock 0; reset; exit"
+```
+
+Then flash normally.
+
+**USB permission issues:** Close serial console sessions before flashing.
+The FTDI kernel driver claims all channels. On macOS, `sudo` may be required.
+On Linux, add your user to the `dialout` group:
+
+```bash
+sudo usermod -a -G dialout $(whoami)
+# Re-login required
+```
+
+## Restore SiFive vendor firmware
+
+```bash
+openocd -f boards/sifive/hifive_premier_p550_mcu/support/p550_openocd.cfg \
+  -c "init; halt; program STM32F407VET6_BMC.elf verify; reset; exit"
 ```

--- a/boards/sifive/hifive_premier_p550_mcu/support/p550_openocd.cfg
+++ b/boards/sifive/hifive_premier_p550_mcu/support/p550_openocd.cfg
@@ -1,0 +1,58 @@
+# HiFive Premier P550 OpenOCD configuration
+#
+# Unified config for both the STM32 BMC (MCU) and the EIC7700X SoC.
+# The FTDI FT4232H provides JTAG on two channels:
+#   Channel 0 (if00) — SoC JTAG (RISC-V P550 quad-core)
+#   Channel 1 (if01) — BMC JTAG/SWD (STM32F407 Cortex-M4)
+#
+# Usage:
+#   Flash BMC (default):
+#     openocd -f p550_openocd.cfg -c 'program wallabmc.signed.hex verify reset exit'
+#
+#   Debug SoC:
+#     openocd -c 'set TARGET soc' -f p550_openocd.cfg
+#
+#   Flash BMC explicitly:
+#     openocd -c 'set TARGET bmc' -f p550_openocd.cfg -c 'program ...'
+
+# Default target is the BMC
+if {![info exists TARGET]} {
+    set TARGET bmc
+}
+
+# Common FTDI settings
+adapter driver ftdi
+ftdi device_desc "Quad RS232-HS"
+ftdi vid_pid 0x0403 0x6011
+
+if {$TARGET eq "bmc"} {
+    # --- STM32F407 BMC (Channel 1) ---
+    ftdi channel 1
+    ftdi layout_init 0x0000 0x001b
+    ftdi layout_signal nTRST -data 0x0010
+    transport select jtag
+    source [find target/stm32f4x.cfg]
+    reset_config trst_only
+
+} elseif {$TARGET eq "soc"} {
+    # --- EIC7700X SoC (Channel 0) ---
+    adapter speed 10000
+    ftdi channel 0
+    ftdi layout_init 0x0008 0x001b
+    ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
+    transport select jtag
+
+    set _CHIPNAME riscv
+    jtag newtap $_CHIPNAME cpu -irlen 5
+
+    target create $_CHIPNAME.cpu0 riscv -chain-position $_CHIPNAME.cpu -coreid 0
+    target create $_CHIPNAME.cpu1 riscv -chain-position $_CHIPNAME.cpu -coreid 1
+    target create $_CHIPNAME.cpu2 riscv -chain-position $_CHIPNAME.cpu -coreid 2
+    target create $_CHIPNAME.cpu3 riscv -chain-position $_CHIPNAME.cpu -coreid 3
+
+    target smp $_CHIPNAME.cpu0 $_CHIPNAME.cpu1 $_CHIPNAME.cpu2 $_CHIPNAME.cpu3
+
+} else {
+    echo "Error: TARGET must be 'bmc' or 'soc', got '$TARGET'"
+    shutdown
+}


### PR DESCRIPTION
Board definition updates for the HiFive Premier P550 MCU:
- DTS: full pin map for power, reset, boot select, fan, I2C, LEDs
- Overlay: aliases for all hardware signals, normalized 4-space indent
- Defconfig: P550-specific Kconfig overrides
- OpenOCD: unified BMC + SoC JTAG config via FT4232H
- Support README: flashing, debugging, serial console docs
- Hardware reference: complete STM32 pin map, boot modes, protocol spec