### PR TITLE
feat: add ESWIN EIC7700X vendor-specific modules

### DIFF
--- a/boards/sifive/hifive_premier_p550_mcu/host-somd/Makefile
+++ b/boards/sifive/hifive_premier_p550_mcu/host-somd/Makefile
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# somd - HiFive Premier P550 SOM daemon
+#
+# Native build on RISC-V host:
+#   make
+#
+# Cross-compile:
+#   make CC=riscv64-linux-gnu-gcc
+
+CC ?= gcc
+CFLAGS ?= -O2 -Wall -Wextra -Wpedantic
+PREFIX ?= /usr/local
+
+somd: somd.c hfp_protocol.h
+	$(CC) $(CFLAGS) -o $@ somd.c
+
+test_protocol: test_protocol.c hfp_protocol.h
+	$(CC) $(CFLAGS) -o $@ test_protocol.c
+
+test: test_protocol
+	./test_protocol
+
+install: somd
+	install -D -m 755 somd $(DESTDIR)$(PREFIX)/sbin/somd
+	install -D -m 644 somd.service $(DESTDIR)/etc/systemd/system/somd.service
+
+clean:
+	rm -f somd test_protocol
+
+.PHONY: install clean test

--- a/boards/sifive/hifive_premier_p550_mcu/host-somd/README.md
+++ b/boards/sifive/hifive_premier_p550_mcu/host-somd/README.md
@@ -1,0 +1,86 @@
+# somd — SOM Protocol Daemon
+
+Host-side daemon for the HiFive Premier P550 that responds to the BMC's
+UART protocol. Without it, the BMC has no way to know the host OS is running.
+
+## Background
+
+The P550 carrier board has a dedicated UART link between the STM32 BMC
+(MCU UART4, PC10/PC11) and the EIC7700X SoC (SoC UART2, 0x50920000).
+The BMC sends 267-byte framed messages to query host status, read
+temperatures, and coordinate shutdown/reboot. The host must respond —
+otherwise the BMC marks the SOM as offline.
+
+The original ESWIN vendor Linux image included a proprietary daemon for
+this purpose. Since WallaBMC replaces the vendor MCU firmware and targets
+standard Linux distributions (RHEL, Fedora) that lack the vendor daemon,
+`somd` provides the host-side implementation.
+
+For the full protocol specification (frame format, command table, checksum
+algorithm), see `boards/sifive/hifive_premier_p550_mcu/doc/hardware.rst`,
+section "MCU-SoC UART4 protocol".
+
+## What it does
+
+- Listens on `/dev/ttyS2` (SoC UART2) at 115200 8N1
+- Receives 267-byte framed requests from the BMC
+- Replies to `CMD_BOARD_STATUS` (0x06) — keepalive acknowledgment
+- Replies to `CMD_PVT_INFO` (0x05) — CPU/NPU temperatures from sysfs
+- Replies `UNSUPPORTED` to unrecognized commands
+
+When somd is running, the BMC reports `SOM daemon state: ONLINE`.
+When somd stops, the BMC detects the loss after 5 missed keepalives
+(~5 seconds) and reports `SOM daemon state: OFFLINE`.
+
+## Build
+
+Native build on the RISC-V host (no dependencies beyond libc):
+
+```bash
+make
+```
+
+Cross-compile from another machine:
+
+```bash
+make CC=riscv64-linux-gnu-gcc
+```
+
+## Install
+
+```bash
+sudo make install
+sudo systemctl enable --now somd
+```
+
+This installs the binary to `/usr/local/sbin/somd` and the systemd unit
+to `/etc/systemd/system/somd.service`.
+
+## Usage
+
+```
+somd [-d /dev/ttyS2] [-f] [-v]
+  -d  Serial device (default: /dev/ttyS2)
+  -f  Run in foreground (log to stderr instead of syslog)
+  -v  Verbose (repeat for more detail)
+```
+
+Test interactively:
+
+```bash
+sudo systemctl stop somd
+sudo ./somd -f -v -d /dev/ttyS2
+```
+
+## Serial port identification
+
+The correct serial port depends on the kernel's device tree enumeration.
+On the P550 with the ESWIN EIC7700X SoC:
+
+| Port | Address | Function |
+|------|---------|----------|
+| ttyS0 | 0x50900000 | SoC UART0 — kernel console |
+| ttyS1 | 0x50910000 | SoC UART1 — unused |
+| ttyS2 | 0x50920000 | SoC UART2 — BMC protocol link |
+
+Verify with: `sudo cat /proc/tty/driver/serial`

--- a/boards/sifive/hifive_premier_p550_mcu/host-somd/hfp_protocol.h
+++ b/boards/sifive/hifive_premier_p550_mcu/host-somd/hfp_protocol.h
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * HiFive Premier P550 BMC-SoC UART protocol definitions.
+ *
+ * Matches the framed message protocol used between the STM32 BMC (MCU UART4)
+ * and the EIC7700X SoC (SoC UART2) at 115200 8N1.
+ *
+ * References:
+ *   - WallaBMC src/som_protocol.h (BMC side)
+ *   - OpenSBI platform/generic/include/eswin/hfp.h (SoC side)
+ *   - ESWIN vendor firmware hf_common.h (original)
+ */
+
+#ifndef HFP_PROTOCOL_H
+#define HFP_PROTOCOL_H
+
+#include <stdint.h>
+
+#define HFP_MAGIC_HEADER	0xA55AAA55
+#define HFP_MAGIC_TAIL		0xBDBABDBA
+#define HFP_DATA_MAX		250
+#define HFP_FRAME_SIZE		267
+
+enum hfp_msg_type {
+	HFP_MSG_REQUEST = 0x01,
+	HFP_MSG_REPLY   = 0x02,
+	HFP_MSG_NOTIFY  = 0x03,
+};
+
+enum hfp_cmd_type {
+	HFP_CMD_POWER_OFF    = 0x01,
+	HFP_CMD_REBOOT       = 0x02,
+	HFP_CMD_BOARD_INFO   = 0x03,
+	HFP_CMD_CONTROL_LED  = 0x04,
+	HFP_CMD_PVT_INFO     = 0x05,
+	HFP_CMD_BOARD_STATUS = 0x06,
+	HFP_CMD_POWER_INFO   = 0x07,
+	HFP_CMD_RESTART      = 0x08,
+};
+
+enum hfp_result {
+	HFP_RESULT_OK          = 0x00,
+	HFP_RESULT_ERROR       = 0x01,
+	HFP_RESULT_INVALID     = 0x02,
+	HFP_RESULT_UNSUPPORTED = 0x03,
+};
+
+struct hfp_message {
+	uint32_t header;
+	uint32_t task_id;
+	uint8_t  msg_type;
+	uint8_t  cmd_type;
+	uint8_t  cmd_result;
+	uint8_t  data_len;
+	uint8_t  data[HFP_DATA_MAX];
+	uint8_t  checksum;
+	uint32_t tail;
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hfp_message) == HFP_FRAME_SIZE,
+	       "hfp_message must be 267 bytes");
+
+struct hfp_pvt_info {
+	int32_t cpu_temp;
+	int32_t npu_temp;
+	int32_t fan_speed;
+} __attribute__((packed));
+
+static inline uint8_t hfp_checksum(const struct hfp_message *msg)
+{
+	uint8_t cs = 0;
+
+	cs ^= msg->msg_type;
+	cs ^= msg->cmd_type;
+	cs ^= msg->data_len;
+	for (int i = 0; i < msg->data_len; i++)
+		cs ^= msg->data[i];
+	return cs;
+}
+
+#endif /* HFP_PROTOCOL_H */

--- a/boards/sifive/hifive_premier_p550_mcu/host-somd/somd.c
+++ b/boards/sifive/hifive_premier_p550_mcu/host-somd/somd.c
@@ -1,0 +1,396 @@
+// SPDX-FileCopyrightText: © 2026 Red Hat, LLC
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * somd - SOM daemon for HiFive Premier P550
+ *
+ * Host-side responder for the BMC UART protocol. Listens on SoC UART2
+ * (typically /dev/ttyS2), receives framed requests from the BMC, and
+ * replies with board status, thermal data, etc.
+ *
+ * Usage: somd [-d /dev/ttyS2] [-f]
+ *   -d  Serial device path (default: /dev/ttyS2)
+ *   -f  Run in foreground (default: background via systemd)
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syslog.h>
+#include <termios.h>
+#include <unistd.h>
+
+#include "hfp_protocol.h"
+
+static volatile sig_atomic_t running = 1;
+static int use_syslog = 1;
+static int verbose;
+
+static void log_msg(int priority, const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	if (use_syslog) {
+		vsyslog(priority, fmt, ap);
+	} else {
+		vfprintf(stderr, fmt, ap);
+		fputc('\n', stderr);
+	}
+	va_end(ap);
+}
+
+static void sig_handler(int sig)
+{
+	(void)sig;
+	running = 0;
+}
+
+static int serial_open(const char *path)
+{
+	struct termios tty;
+	int fd;
+
+	fd = open(path, O_RDWR | O_NOCTTY);
+	if (fd < 0) {
+		log_msg(LOG_ERR, "open %s: %s", path, strerror(errno));
+		return -1;
+	}
+
+	if (tcgetattr(fd, &tty) < 0) {
+		log_msg(LOG_ERR, "tcgetattr: %s", strerror(errno));
+		close(fd);
+		return -1;
+	}
+
+	cfmakeraw(&tty);
+	cfsetispeed(&tty, B115200);
+	cfsetospeed(&tty, B115200);
+
+	tty.c_cflag &= ~(CSIZE | PARENB | CSTOPB | CRTSCTS);
+	tty.c_cflag |= CS8 | CLOCAL | CREAD;
+	tty.c_cc[VMIN] = 1;
+	tty.c_cc[VTIME] = 0;
+
+	if (tcsetattr(fd, TCSANOW, &tty) < 0) {
+		log_msg(LOG_ERR, "tcsetattr: %s", strerror(errno));
+		close(fd);
+		return -1;
+	}
+
+	tcflush(fd, TCIOFLUSH);
+	return fd;
+}
+
+static int read_exact(int fd, void *buf, size_t len)
+{
+	size_t pos = 0;
+	uint8_t *p = buf;
+
+	while (pos < len) {
+		ssize_t n = read(fd, p + pos, len - pos);
+
+		if (n < 0) {
+			if (errno == EINTR)
+				continue;
+			return -1;
+		}
+		if (n == 0)
+			return -1;
+		pos += n;
+	}
+	return 0;
+}
+
+static int write_exact(int fd, const void *buf, size_t len)
+{
+	size_t pos = 0;
+	const uint8_t *p = buf;
+
+	while (pos < len) {
+		ssize_t n = write(fd, p + pos, len - pos);
+
+		if (n < 0) {
+			if (errno == EINTR)
+				continue;
+			return -1;
+		}
+		pos += n;
+	}
+	return 0;
+}
+
+/*
+ * Scan the byte stream for the 4-byte magic header.
+ * Returns 0 on success with the header already consumed, -1 on error.
+ */
+static int sync_to_header(int fd)
+{
+	const uint8_t hdr[] = {
+		(HFP_MAGIC_HEADER >>  0) & 0xFF,
+		(HFP_MAGIC_HEADER >>  8) & 0xFF,
+		(HFP_MAGIC_HEADER >> 16) & 0xFF,
+		(HFP_MAGIC_HEADER >> 24) & 0xFF,
+	};
+	int match = 0;
+	uint8_t byte;
+
+	while (running) {
+		ssize_t n = read(fd, &byte, 1);
+
+		if (n < 0) {
+			if (errno == EINTR)
+				continue;
+			return -1;
+		}
+		if (n == 0)
+			return -1;
+
+		if (verbose > 1)
+			log_msg(LOG_DEBUG, "rx byte: 0x%02x (match=%d)", byte, match);
+
+		if (byte == hdr[match]) {
+			match++;
+			if (match == 4) {
+				if (verbose)
+					log_msg(LOG_INFO, "header sync");
+				return 0;
+			}
+		} else {
+			match = (byte == hdr[0]) ? 1 : 0;
+		}
+	}
+	return -1;
+}
+
+static int read_thermal(const char *path)
+{
+	FILE *f;
+	int val = -1;
+
+	f = fopen(path, "r");
+	if (!f)
+		return -1;
+	if (fscanf(f, "%d", &val) != 1)
+		val = -1;
+	fclose(f);
+	return val;
+}
+
+/*
+ * Try common sysfs thermal zone paths for the EIC7700X.
+ * Returns temperature in millidegrees Celsius, or -1.
+ */
+static int read_cpu_temp(void)
+{
+	int val;
+
+	val = read_thermal("/sys/class/thermal/thermal_zone0/temp");
+	if (val >= 0)
+		return val;
+	return -1;
+}
+
+static int read_npu_temp(void)
+{
+	int val;
+
+	val = read_thermal("/sys/class/thermal/thermal_zone1/temp");
+	if (val >= 0)
+		return val;
+	return -1;
+}
+
+static void handle_pvt_info(struct hfp_message *reply)
+{
+	struct hfp_pvt_info pvt = {
+		.cpu_temp  = read_cpu_temp(),
+		.npu_temp  = read_npu_temp(),
+		.fan_speed = -1,
+	};
+
+	reply->data_len = sizeof(pvt);
+	memcpy(reply->data, &pvt, sizeof(pvt));
+}
+
+static void send_reply(int fd, const struct hfp_message *req,
+		       uint8_t result, const uint8_t *data, uint8_t data_len)
+{
+	struct hfp_message reply;
+
+	memset(&reply, 0, sizeof(reply));
+	reply.header = HFP_MAGIC_HEADER;
+	reply.task_id = req->task_id;
+	reply.msg_type = HFP_MSG_REPLY;
+	reply.cmd_type = req->cmd_type;
+	reply.cmd_result = result;
+	reply.tail = HFP_MAGIC_TAIL;
+
+	if (data && data_len > 0) {
+		reply.data_len = data_len;
+		memcpy(reply.data, data, data_len);
+	}
+
+	reply.checksum = hfp_checksum(&reply);
+
+	if (write_exact(fd, &reply, sizeof(reply)) < 0)
+		log_msg(LOG_ERR, "write reply: %s", strerror(errno));
+}
+
+static void send_notify(int fd, uint8_t cmd)
+{
+	struct hfp_message msg;
+
+	memset(&msg, 0, sizeof(msg));
+	msg.header = HFP_MAGIC_HEADER;
+	msg.msg_type = HFP_MSG_NOTIFY;
+	msg.cmd_type = cmd;
+	msg.tail = HFP_MAGIC_TAIL;
+	msg.checksum = hfp_checksum(&msg);
+
+	write_exact(fd, &msg, sizeof(msg));
+	tcdrain(fd);
+}
+
+static void handle_request(int fd, const struct hfp_message *req)
+{
+	struct hfp_message reply;
+
+	switch (req->cmd_type) {
+	case HFP_CMD_BOARD_STATUS:
+		send_reply(fd, req, HFP_RESULT_OK, NULL, 0);
+		break;
+
+	case HFP_CMD_PVT_INFO:
+		memset(&reply, 0, sizeof(reply));
+		reply.header = HFP_MAGIC_HEADER;
+		reply.task_id = req->task_id;
+		reply.msg_type = HFP_MSG_REPLY;
+		reply.cmd_type = req->cmd_type;
+		reply.cmd_result = HFP_RESULT_OK;
+		reply.tail = HFP_MAGIC_TAIL;
+		handle_pvt_info(&reply);
+		reply.checksum = hfp_checksum(&reply);
+		if (write_exact(fd, &reply, sizeof(reply)) < 0)
+			log_msg(LOG_ERR, "write reply: %s", strerror(errno));
+		break;
+
+	case HFP_CMD_POWER_OFF:
+		log_msg(LOG_INFO, "BMC requested poweroff");
+		send_reply(fd, req, HFP_RESULT_OK, NULL, 0);
+		tcdrain(fd);
+		if (system("/sbin/poweroff") != 0)
+			log_msg(LOG_ERR, "poweroff failed");
+		send_notify(fd, HFP_CMD_POWER_OFF);
+		running = 0;
+		break;
+
+	case HFP_CMD_RESTART:
+		log_msg(LOG_INFO, "BMC requested reboot");
+		send_reply(fd, req, HFP_RESULT_OK, NULL, 0);
+		tcdrain(fd);
+		if (system("/sbin/reboot") != 0)
+			log_msg(LOG_ERR, "reboot failed");
+		send_notify(fd, HFP_CMD_RESTART);
+		running = 0;
+		break;
+
+	default:
+		log_msg(LOG_DEBUG, "unsupported cmd 0x%02x", req->cmd_type);
+		send_reply(fd, req, HFP_RESULT_UNSUPPORTED, NULL, 0);
+		break;
+	}
+}
+
+static void usage(const char *prog)
+{
+	fprintf(stderr, "Usage: %s [-d device] [-f] [-v]\n", prog);
+	fprintf(stderr, "  -d  Serial device (default: /dev/ttyS2)\n");
+	fprintf(stderr, "  -f  Foreground mode\n");
+	fprintf(stderr, "  -v  Verbose (repeat for more)\n");
+	exit(1);
+}
+
+int main(int argc, char *argv[])
+{
+	const char *dev = "/dev/ttyS2";
+	int foreground = 0;
+	int fd, opt;
+
+	while ((opt = getopt(argc, argv, "d:fvh")) != -1) {
+		switch (opt) {
+		case 'd':
+			dev = optarg;
+			break;
+		case 'f':
+			foreground = 1;
+			break;
+		case 'v':
+			verbose++;
+			break;
+		default:
+			usage(argv[0]);
+		}
+	}
+
+	if (foreground)
+		use_syslog = 0;
+	else
+		openlog("somd", LOG_PID, LOG_DAEMON);
+
+	signal(SIGTERM, sig_handler);
+	signal(SIGINT, sig_handler);
+
+	fd = serial_open(dev);
+	if (fd < 0)
+		return 1;
+
+	log_msg(LOG_INFO, "somd started on %s", dev);
+
+	while (running) {
+		struct hfp_message msg;
+
+		if (sync_to_header(fd) < 0)
+			break;
+
+		msg.header = HFP_MAGIC_HEADER;
+		if (read_exact(fd, (uint8_t *)&msg + 4, sizeof(msg) - 4) < 0) {
+			if (running)
+				log_msg(LOG_ERR, "read: %s", strerror(errno));
+			break;
+		}
+
+		if (verbose)
+			log_msg(LOG_INFO, "frame: type=0x%02x cmd=0x%02x result=0x%02x len=%d tail=0x%08x task=0x%08x",
+				msg.msg_type, msg.cmd_type, msg.cmd_result,
+				msg.data_len, msg.tail, msg.task_id);
+
+		if (msg.tail != HFP_MAGIC_TAIL) {
+			log_msg(LOG_WARNING, "bad tail 0x%08x", msg.tail);
+			continue;
+		}
+
+		if (hfp_checksum(&msg) != msg.checksum) {
+			log_msg(LOG_WARNING, "checksum mismatch: got 0x%02x expected 0x%02x",
+				msg.checksum, hfp_checksum(&msg));
+			continue;
+		}
+
+		if (msg.msg_type == HFP_MSG_REQUEST) {
+			if (verbose)
+				log_msg(LOG_INFO, "replying to cmd 0x%02x", msg.cmd_type);
+			handle_request(fd, &msg);
+		}
+	}
+
+	log_msg(LOG_INFO, "somd stopping");
+	close(fd);
+
+	if (!foreground)
+		closelog();
+
+	return 0;
+}

--- a/boards/sifive/hifive_premier_p550_mcu/host-somd/somd.service
+++ b/boards/sifive/hifive_premier_p550_mcu/host-somd/somd.service
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+[Unit]
+Description=WallaBMC SOM protocol daemon
+After=dev-ttyS2.device
+BindsTo=dev-ttyS2.device
+
+[Service]
+Type=simple
+ExecStart=/usr/local/sbin/somd
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/boards/sifive/hifive_premier_p550_mcu/host-somd/test_protocol.c
+++ b/boards/sifive/hifive_premier_p550_mcu/host-somd/test_protocol.c
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * Unit tests for the HFP protocol and somd command handling.
+ * Uses a minimal assert-based harness — no external dependencies.
+ *
+ * Build: make test
+ * Run:   ./test_protocol
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "hfp_protocol.h"
+
+static int tests_run;
+static int tests_passed;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  %-50s ", #name); \
+	name(); \
+	tests_passed++; \
+	printf("OK\n"); \
+} while (0)
+
+/* --- Protocol tests --- */
+
+static void test_frame_size(void)
+{
+	assert(sizeof(struct hfp_message) == HFP_FRAME_SIZE);
+	assert(HFP_FRAME_SIZE == 267);
+}
+
+static void test_checksum_empty_data(void)
+{
+	struct hfp_message msg = {0};
+
+	msg.msg_type = HFP_MSG_REPLY;
+	msg.cmd_type = HFP_CMD_BOARD_STATUS;
+	msg.data_len = 0;
+
+	uint8_t cs = hfp_checksum(&msg);
+	assert(cs == (0x02 ^ 0x06 ^ 0x00));
+}
+
+static void test_checksum_with_data(void)
+{
+	struct hfp_message msg = {0};
+
+	msg.msg_type = HFP_MSG_REQUEST;
+	msg.cmd_type = HFP_CMD_PVT_INFO;
+	msg.data_len = 3;
+	msg.data[0] = 0xAA;
+	msg.data[1] = 0xBB;
+	msg.data[2] = 0xCC;
+
+	uint8_t expected = 0x01 ^ 0x05 ^ 0x03 ^ 0xAA ^ 0xBB ^ 0xCC;
+	assert(hfp_checksum(&msg) == expected);
+}
+
+static void test_checksum_excludes_cmd_result(void)
+{
+	struct hfp_message msg1 = {0};
+	struct hfp_message msg2 = {0};
+
+	msg1.msg_type = HFP_MSG_REPLY;
+	msg1.cmd_type = HFP_CMD_BOARD_STATUS;
+	msg1.cmd_result = HFP_RESULT_OK;
+
+	msg2.msg_type = HFP_MSG_REPLY;
+	msg2.cmd_type = HFP_CMD_BOARD_STATUS;
+	msg2.cmd_result = HFP_RESULT_ERROR;
+
+	assert(hfp_checksum(&msg1) == hfp_checksum(&msg2));
+}
+
+static void test_magic_values(void)
+{
+	assert(HFP_MAGIC_HEADER == 0xA55AAA55);
+	assert(HFP_MAGIC_TAIL == 0xBDBABDBA);
+}
+
+static void test_command_enum_values(void)
+{
+	assert(HFP_CMD_POWER_OFF == 0x01);
+	assert(HFP_CMD_REBOOT == 0x02);
+	assert(HFP_CMD_BOARD_INFO == 0x03);
+	assert(HFP_CMD_PVT_INFO == 0x05);
+	assert(HFP_CMD_BOARD_STATUS == 0x06);
+	assert(HFP_CMD_RESTART == 0x08);
+}
+
+static void test_pvt_info_struct_size(void)
+{
+	assert(sizeof(struct hfp_pvt_info) == 12);
+}
+
+/* --- Reply construction tests --- */
+
+static void test_build_board_status_reply(void)
+{
+	struct hfp_message req = {
+		.header = HFP_MAGIC_HEADER,
+		.task_id = 0x12345678,
+		.msg_type = HFP_MSG_REQUEST,
+		.cmd_type = HFP_CMD_BOARD_STATUS,
+		.tail = HFP_MAGIC_TAIL,
+	};
+
+	struct hfp_message reply;
+
+	memset(&reply, 0, sizeof(reply));
+	reply.header = HFP_MAGIC_HEADER;
+	reply.task_id = req.task_id;
+	reply.msg_type = HFP_MSG_REPLY;
+	reply.cmd_type = req.cmd_type;
+	reply.cmd_result = HFP_RESULT_OK;
+	reply.tail = HFP_MAGIC_TAIL;
+	reply.checksum = hfp_checksum(&reply);
+
+	assert(reply.header == HFP_MAGIC_HEADER);
+	assert(reply.task_id == 0x12345678);
+	assert(reply.msg_type == HFP_MSG_REPLY);
+	assert(reply.cmd_type == HFP_CMD_BOARD_STATUS);
+	assert(reply.cmd_result == HFP_RESULT_OK);
+	assert(reply.data_len == 0);
+	assert(reply.tail == HFP_MAGIC_TAIL);
+	assert(reply.checksum == hfp_checksum(&reply));
+}
+
+static void test_build_power_off_reply(void)
+{
+	struct hfp_message req = {
+		.header = HFP_MAGIC_HEADER,
+		.task_id = 0xAABBCCDD,
+		.msg_type = HFP_MSG_REQUEST,
+		.cmd_type = HFP_CMD_POWER_OFF,
+		.tail = HFP_MAGIC_TAIL,
+	};
+
+	struct hfp_message reply;
+
+	memset(&reply, 0, sizeof(reply));
+	reply.header = HFP_MAGIC_HEADER;
+	reply.task_id = req.task_id;
+	reply.msg_type = HFP_MSG_REPLY;
+	reply.cmd_type = req.cmd_type;
+	reply.cmd_result = HFP_RESULT_OK;
+	reply.tail = HFP_MAGIC_TAIL;
+	reply.checksum = hfp_checksum(&reply);
+
+	assert(reply.task_id == req.task_id);
+	assert(reply.cmd_type == HFP_CMD_POWER_OFF);
+	assert(reply.cmd_result == HFP_RESULT_OK);
+}
+
+static void test_build_restart_reply(void)
+{
+	struct hfp_message req = {
+		.header = HFP_MAGIC_HEADER,
+		.task_id = 0x11223344,
+		.msg_type = HFP_MSG_REQUEST,
+		.cmd_type = HFP_CMD_RESTART,
+		.tail = HFP_MAGIC_TAIL,
+	};
+
+	struct hfp_message reply;
+
+	memset(&reply, 0, sizeof(reply));
+	reply.header = HFP_MAGIC_HEADER;
+	reply.task_id = req.task_id;
+	reply.msg_type = HFP_MSG_REPLY;
+	reply.cmd_type = req.cmd_type;
+	reply.cmd_result = HFP_RESULT_OK;
+	reply.tail = HFP_MAGIC_TAIL;
+	reply.checksum = hfp_checksum(&reply);
+
+	assert(reply.task_id == req.task_id);
+	assert(reply.cmd_type == HFP_CMD_RESTART);
+	assert(reply.cmd_result == HFP_RESULT_OK);
+}
+
+int main(void)
+{
+	printf("somd protocol tests:\n");
+
+	TEST(test_frame_size);
+	TEST(test_checksum_empty_data);
+	TEST(test_checksum_with_data);
+	TEST(test_checksum_excludes_cmd_result);
+	TEST(test_magic_values);
+	TEST(test_command_enum_values);
+	TEST(test_pvt_info_struct_size);
+	TEST(test_build_board_status_reply);
+	TEST(test_build_power_off_reply);
+	TEST(test_build_restart_reply);
+
+	printf("\n%d/%d tests passed\n", tests_passed, tests_run);
+	return tests_passed == tests_run ? 0 : 1;
+}

--- a/src/eswin/Kconfig.board_identity
+++ b/src/eswin/Kconfig.board_identity
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Red Hat, LLC
+# Carrier board identity from EEPROM
+
+config BOARD_IDENTITY
+	bool "Board identity from EEPROM"
+	default y
+	depends on EEPROM
+	help
+	  Read carrier board identity (serial number, MAC addresses,
+	  PCB revision) from AT24C02C EEPROM on I2C1. Requires the
+	  I2C mux (PA3) to route the shared bus to the MCU.

--- a/src/eswin/Kconfig.bootsel
+++ b/src/eswin/Kconfig.bootsel
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Red Hat, LLC
+# SOM boot mode selection (BOOT_SEL[3:0])
+
+config BOOTSEL
+	bool "SOM boot mode selection"
+	default y
+	depends on $(dt_alias_enabled,bootsel-0)
+	help
+	  Control the SOM boot source via BOOT_SEL[3:0] GPIO pins.
+	  Supports hardware mode (follow DIP switch) and software mode
+	  (MCU drives the pins).

--- a/src/eswin/Kconfig.som_protocol
+++ b/src/eswin/Kconfig.som_protocol
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Red Hat, LLC
+# SOM-MCU UART protocol (UART4 ↔ SoC UART2)
+
+config SOM_PROTOCOL
+	bool "SOM-MCU UART4 communication protocol"
+	default y
+	depends on $(dt_nodelabel_enabled,uart4)
+	select SERIAL
+	select UART_INTERRUPT_DRIVEN
+	help
+	  Bidirectional framed protocol between the BMC (MCU UART4) and the
+	  SoC (SoC UART2). Used for keepalive, PVT queries, and graceful
+	  shutdown/restart coordination with the host-side somd daemon.
+
+if SOM_PROTOCOL
+
+config SOM_PROTOCOL_STACK_SIZE
+	int "SOM protocol thread stack size"
+	default 2048
+
+config SOM_PROTOCOL_PRIORITY
+	int "SOM protocol thread priority"
+	default 5
+
+config SOM_PROTOCOL_TX_TIMEOUT_MS
+	int "SOM command response timeout (ms)"
+	default 2000
+
+config SOM_KEEPALIVE
+	bool "SOM keepalive health monitor"
+	default y
+
+config SOM_KEEPALIVE_INTERVAL_MS
+	int "Keepalive poll interval (ms)"
+	default 1000
+	depends on SOM_KEEPALIVE
+
+config SOM_KEEPALIVE_FAIL_THRESHOLD
+	int "Consecutive failures before marking SOM offline"
+	default 5
+	depends on SOM_KEEPALIVE
+
+config SOM_KEEPALIVE_STACK_SIZE
+	int "Keepalive thread stack size"
+	default 1024
+	depends on SOM_KEEPALIVE
+
+config GRACEFUL_SHUTDOWN_TIMEOUT_MS
+	int "Graceful shutdown timeout (ms)"
+	default 60000
+	help
+	  Time to wait for SOM to send shutdown NOTIFY before forcing
+	  power off. Linux shutdown can take 30+ seconds for service
+	  stops and filesystem sync.
+
+config GRACEFUL_REBOOT_TIMEOUT_MS
+	int "Graceful reboot timeout (ms)"
+	default 60000
+	help
+	  Time to wait for SOM to send reboot NOTIFY before forcing
+	  reset. Linux reboot can take 30+ seconds.
+
+endif # SOM_PROTOCOL

--- a/src/eswin/board_identity.c
+++ b/src/eswin/board_identity.c
@@ -1,0 +1,171 @@
+/*
+ * SPDX-FileCopyrightText: © 2026 Red Hat, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/eeprom.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/crc.h>
+#include <string.h>
+
+static uint32_t vendor_crc32(const uint8_t *data, size_t len)
+{
+	return crc32_ieee_update(0xFFFFFFFF, data, len);
+}
+
+#include "board_identity.h"
+
+LOG_MODULE_REGISTER(board_identity, LOG_LEVEL_INF);
+
+static const struct device *eeprom_dev = DEVICE_DT_GET(DT_NODELABEL(eeprom));
+
+#define I2C_MUX_EN_NODE DT_ALIAS(i2c_mux_en)
+#if DT_NODE_EXISTS(I2C_MUX_EN_NODE)
+static const struct gpio_dt_spec i2c_mux_gpio =
+	GPIO_DT_SPEC_GET(I2C_MUX_EN_NODE, gpios);
+#endif
+
+#define EEPROM_WP_NODE DT_ALIAS(eeprom_wp)
+#if DT_NODE_EXISTS(EEPROM_WP_NODE)
+static const struct gpio_dt_spec eeprom_wp_gpio =
+	GPIO_DT_SPEC_GET(EEPROM_WP_NODE, gpios);
+#endif
+
+static struct carrier_board_info cbinfo;
+static bool cbinfo_valid;
+
+const struct carrier_board_info *board_identity_get(void)
+{
+	return cbinfo_valid ? &cbinfo : NULL;
+}
+
+const uint8_t *board_identity_mac(void)
+{
+	return cbinfo_valid ? cbinfo.mac_mcu : NULL;
+}
+
+const char *board_identity_serial(void)
+{
+	static char serial_str[BOARD_SERIAL_LEN + 1];
+
+	if (!cbinfo_valid) {
+		return "unknown";
+	}
+
+	memcpy(serial_str, cbinfo.serial_number, BOARD_SERIAL_LEN);
+	serial_str[BOARD_SERIAL_LEN] = '\0';
+	return serial_str;
+}
+
+static int cmd_board_info(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	if (!cbinfo_valid) {
+		shell_print(sh, "Retrying EEPROM read...");
+		int rc = board_identity_init();
+		if (rc < 0) {
+			shell_error(sh, "Board identity not available (err %d)", rc);
+			return rc;
+		}
+	}
+
+	shell_print(sh, "--- Carrier Board Info ---");
+	shell_print(sh, "Serial: %s", board_identity_serial());
+	shell_print(sh, "Product ID: 0x%04x", cbinfo.product_id);
+	shell_print(sh, "PCB rev: %d, BOM rev: %d, BOM variant: %d",
+		    cbinfo.pcb_revision, cbinfo.bom_revision,
+		    cbinfo.bom_variant);
+	shell_print(sh, "MCU MAC: %02x:%02x:%02x:%02x:%02x:%02x",
+		    cbinfo.mac_mcu[0], cbinfo.mac_mcu[1], cbinfo.mac_mcu[2],
+		    cbinfo.mac_mcu[3], cbinfo.mac_mcu[4], cbinfo.mac_mcu[5]);
+	shell_print(sh, "SOM MAC0: %02x:%02x:%02x:%02x:%02x:%02x",
+		    cbinfo.mac_som0[0], cbinfo.mac_som0[1], cbinfo.mac_som0[2],
+		    cbinfo.mac_som0[3], cbinfo.mac_som0[4], cbinfo.mac_som0[5]);
+	shell_print(sh, "SOM MAC1: %02x:%02x:%02x:%02x:%02x:%02x",
+		    cbinfo.mac_som1[0], cbinfo.mac_som1[1], cbinfo.mac_som1[2],
+		    cbinfo.mac_som1[3], cbinfo.mac_som1[4], cbinfo.mac_som1[5]);
+
+	return 0;
+}
+
+SHELL_CMD_REGISTER(board_info, NULL, "Show carrier board identity from EEPROM",
+		   cmd_board_info);
+
+int board_identity_init(void)
+{
+	int ret;
+
+#if DT_NODE_EXISTS(I2C_MUX_EN_NODE)
+	if (gpio_is_ready_dt(&i2c_mux_gpio)) {
+		gpio_pin_configure_dt(&i2c_mux_gpio, GPIO_OUTPUT_ACTIVE);
+		gpio_pin_set_dt(&i2c_mux_gpio, 1);
+		k_msleep(10);
+	} else {
+		LOG_WRN("I2C mux GPIO not ready");
+	}
+#endif
+
+	if (!device_is_ready(eeprom_dev)) {
+		ret = device_init(eeprom_dev);
+		if (ret < 0) {
+			LOG_ERR("EEPROM device init failed: %d", ret);
+			return ret;
+		}
+	}
+
+#if DT_NODE_EXISTS(EEPROM_WP_NODE)
+	if (gpio_is_ready_dt(&eeprom_wp_gpio)) {
+		gpio_pin_configure_dt(&eeprom_wp_gpio, GPIO_OUTPUT_ACTIVE);
+		gpio_pin_set_dt(&eeprom_wp_gpio, 1);
+	}
+#endif
+
+	ret = eeprom_read(eeprom_dev, 0, &cbinfo, sizeof(cbinfo));
+	if (ret < 0) {
+		LOG_ERR("Failed to read EEPROM: %d", ret);
+		return ret;
+	}
+
+	if (cbinfo.magic != CBINFO_MAGIC) {
+		LOG_WRN("EEPROM magic mismatch: 0x%08x (expected 0x%08x)",
+			cbinfo.magic, CBINFO_MAGIC);
+		cbinfo_valid = false;
+		return -EINVAL;
+	}
+
+	size_t crc_len = offsetof(struct carrier_board_info, crc32);
+
+	uint32_t calc_crc = vendor_crc32((const uint8_t *)&cbinfo, crc_len);
+
+	if (calc_crc != cbinfo.crc32) {
+		LOG_WRN("EEPROM CRC mismatch: calc=0x%08x stored=0x%08x",
+			calc_crc, cbinfo.crc32);
+		ret = eeprom_read(eeprom_dev, 80, &cbinfo, sizeof(cbinfo));
+		if (ret < 0 || cbinfo.magic != CBINFO_MAGIC) {
+			LOG_ERR("Backup EEPROM also invalid");
+			cbinfo_valid = false;
+			return -EINVAL;
+		}
+		calc_crc = vendor_crc32((const uint8_t *)&cbinfo, crc_len);
+		if (calc_crc != cbinfo.crc32) {
+			LOG_ERR("Backup EEPROM CRC also invalid");
+			cbinfo_valid = false;
+			return -EINVAL;
+		}
+		LOG_INF("Using backup EEPROM data");
+	}
+
+	cbinfo_valid = true;
+	LOG_INF("Board serial: %s", board_identity_serial());
+	LOG_INF("MCU MAC: %02x:%02x:%02x:%02x:%02x:%02x",
+		cbinfo.mac_mcu[0], cbinfo.mac_mcu[1], cbinfo.mac_mcu[2],
+		cbinfo.mac_mcu[3], cbinfo.mac_mcu[4], cbinfo.mac_mcu[5]);
+
+	return 0;
+}

--- a/src/eswin/board_identity.h
+++ b/src/eswin/board_identity.h
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: © 2026 Red Hat, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef __BOARD_IDENTITY_H__
+#define __BOARD_IDENTITY_H__
+
+#include <stdint.h>
+
+#define BOARD_SERIAL_LEN 18
+
+struct carrier_board_info {
+	uint32_t magic;
+	uint8_t  format_version;
+	uint16_t product_id;
+	uint8_t  pcb_revision;
+	uint8_t  bom_revision;
+	uint8_t  bom_variant;
+	char     serial_number[BOARD_SERIAL_LEN];
+	uint8_t  mfg_test_status;
+	uint8_t  mac_som0[6];
+	uint8_t  mac_som1[6];
+	uint8_t  mac_mcu[6];
+	uint32_t crc32;
+} __packed;
+
+#define CBINFO_MAGIC 0x45505EF1
+
+#ifdef CONFIG_BOARD_IDENTITY
+int board_identity_init(void);
+const struct carrier_board_info *board_identity_get(void);
+const uint8_t *board_identity_mac(void);
+const char *board_identity_serial(void);
+#else
+static inline int board_identity_init(void) { return 0; }
+static inline const uint8_t *board_identity_mac(void) { return NULL; }
+static inline const char *board_identity_serial(void) { return "unknown"; }
+#endif
+
+#endif

--- a/src/eswin/bootsel.c
+++ b/src/eswin/bootsel.c
@@ -1,0 +1,174 @@
+/*
+ * SPDX-FileCopyrightText: © 2026 Red Hat, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/logging/log.h>
+#include <stdlib.h>
+
+#include "bootsel.h"
+
+LOG_MODULE_REGISTER(bootsel, LOG_LEVEL_INF);
+
+#define BOOTSEL_COUNT 4
+
+static const struct gpio_dt_spec bootsel_gpios[BOOTSEL_COUNT] = {
+	GPIO_DT_SPEC_GET(DT_ALIAS(bootsel_0), gpios),
+	GPIO_DT_SPEC_GET(DT_ALIAS(bootsel_1), gpios),
+	GPIO_DT_SPEC_GET(DT_ALIAS(bootsel_2), gpios),
+	GPIO_DT_SPEC_GET(DT_ALIAS(bootsel_3), gpios),
+};
+
+/* false = HW mode (input, follows DIP switch), true = SW mode (output) */
+static bool sw_mode;
+
+int bootsel_set_hw_mode(void)
+{
+	for (int i = 0; i < BOOTSEL_COUNT; i++) {
+		int ret = gpio_pin_configure_dt(&bootsel_gpios[i], GPIO_INPUT);
+		if (ret < 0) {
+			LOG_ERR("Failed to set BOOT_SEL%d to input: %d", i, ret);
+			return ret;
+		}
+	}
+	sw_mode = false;
+	LOG_INF("Boot select: hardware mode (following DIP switch)");
+	return 0;
+}
+
+int bootsel_set_sw_mode(uint8_t value)
+{
+	for (int i = 0; i < BOOTSEL_COUNT; i++) {
+		int ret = gpio_pin_configure_dt(&bootsel_gpios[i],
+						GPIO_OUTPUT_INACTIVE);
+		if (ret < 0) {
+			LOG_ERR("Failed to set BOOT_SEL%d to output: %d",
+				i, ret);
+			return ret;
+		}
+		ret = gpio_pin_set_dt(&bootsel_gpios[i], (value >> i) & 1);
+		if (ret < 0) {
+			LOG_ERR("Failed to drive BOOT_SEL%d: %d", i, ret);
+			return ret;
+		}
+	}
+	sw_mode = true;
+	LOG_INF("Boot select: software mode, value=0x%x", value);
+	return 0;
+}
+
+int bootsel_read(uint8_t *value)
+{
+	*value = 0;
+	for (int i = 0; i < BOOTSEL_COUNT; i++) {
+		int val = gpio_pin_get_dt(&bootsel_gpios[i]);
+		if (val < 0) {
+			return val;
+		}
+		*value |= (val & 1) << i;
+	}
+	return 0;
+}
+
+bool bootsel_is_sw_mode(void)
+{
+	return sw_mode;
+}
+
+const char *bootsel_boot_source(uint8_t sel)
+{
+	switch (sel & 0x0F) {
+	case 0x00: return "SCPU ROM -> UART";
+	case 0x01: return "SCPU ROM -> eMMC";
+	case 0x02: return "SCPU ROM -> SPI NOR";
+	case 0x03: return "SCPU ROM -> USB";
+	case 0x04: return "SCPU SPI NOR -> UART";
+	case 0x05: return "SCPU SPI NOR -> eMMC";
+	case 0x06: return "SCPU SPI NOR -> SPI NOR";
+	case 0x07: return "SCPU SPI NOR -> USB";
+	default:
+		if ((sel & 0x03) == 0x00) return "U84 SPI NOR -> UART";
+		if ((sel & 0x03) == 0x01) return "U84 SPI NOR -> eMMC";
+		if ((sel & 0x03) == 0x02) return "U84 SPI NOR -> SPI NOR";
+		if ((sel & 0x03) == 0x03) return "U84 SPI NOR -> USB";
+		return "Unknown";
+	}
+}
+
+static int cmd_bootsel_get(const struct shell *sh, size_t argc, char **argv)
+{
+	uint8_t val;
+	int ret;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	ret = bootsel_read(&val);
+	if (ret < 0) {
+		shell_error(sh, "Failed to read boot select: %d", ret);
+		return ret;
+	}
+
+	shell_print(sh, "Mode: %s", sw_mode ? "SOFTWARE" : "HARDWARE (DIP switch)");
+	shell_print(sh, "BOOT_SEL[3:0] = 0x%x (0b%d%d%d%d)",
+		    val,
+		    (val >> 3) & 1, (val >> 2) & 1,
+		    (val >> 1) & 1, (val >> 0) & 1);
+	shell_print(sh, "Boot source: %s", bootsel_boot_source(val));
+
+	return 0;
+}
+
+static int cmd_bootsel_set(const struct shell *sh, size_t argc, char **argv)
+{
+	if (argc < 2) {
+		shell_error(sh, "Usage: bootsel set <0-15|hw>");
+		return -EINVAL;
+	}
+
+	if (strcmp(argv[1], "hw") == 0) {
+		return bootsel_set_hw_mode();
+	}
+
+	unsigned long val = strtoul(argv[1], NULL, 0);
+	if (val > 15) {
+		shell_error(sh, "Value must be 0-15 (4-bit boot select)");
+		return -EINVAL;
+	}
+
+	int ret = bootsel_set_sw_mode((uint8_t)val);
+	if (ret < 0) {
+		shell_error(sh, "Failed to set boot select: %d", ret);
+		return ret;
+	}
+
+	shell_print(sh, "Boot select set to 0x%lx (%s)", val,
+		    bootsel_boot_source((uint8_t)val));
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_bootsel_cmds,
+	SHELL_CMD(get, NULL, "Get current boot select configuration", cmd_bootsel_get),
+	SHELL_CMD_ARG(set, NULL,
+		"Set boot select: <0-15> for SW mode, 'hw' for HW (DIP switch) mode",
+		cmd_bootsel_set, 2, 0),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_CMD_REGISTER(bootsel, &sub_bootsel_cmds, "SOM boot mode selection", NULL);
+
+int bootsel_init(void)
+{
+	for (int i = 0; i < BOOTSEL_COUNT; i++) {
+		if (!gpio_is_ready_dt(&bootsel_gpios[i])) {
+			LOG_ERR("BOOT_SEL%d GPIO not ready", i);
+			return -ENODEV;
+		}
+	}
+
+	return bootsel_set_hw_mode();
+}

--- a/src/eswin/bootsel.h
+++ b/src/eswin/bootsel.h
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: © 2026 Red Hat, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef __BOOTSEL_H__
+#define __BOOTSEL_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef CONFIG_BOOTSEL
+int bootsel_init(void);
+int bootsel_read(uint8_t *value);
+int bootsel_set_sw_mode(uint8_t value);
+int bootsel_set_hw_mode(void);
+bool bootsel_is_sw_mode(void);
+const char *bootsel_boot_source(uint8_t sel);
+#else
+static inline int bootsel_init(void) { return 0; }
+static inline int bootsel_read(uint8_t *value) { *value = 0; return 0; }
+static inline int bootsel_set_sw_mode(uint8_t value) { return -ENOTSUP; }
+static inline int bootsel_set_hw_mode(void) { return -ENOTSUP; }
+static inline bool bootsel_is_sw_mode(void) { return false; }
+static inline const char *bootsel_boot_source(uint8_t sel) { return "Unknown"; }
+#endif
+
+#endif

--- a/src/eswin/som_protocol.c
+++ b/src/eswin/som_protocol.c
@@ -1,0 +1,361 @@
+/*
+ * SPDX-FileCopyrightText: © 2026 Red Hat, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/sys/ring_buffer.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/logging/log.h>
+#include <string.h>
+
+#include "som_protocol.h"
+#include "power.h"
+
+LOG_MODULE_REGISTER(som_protocol, LOG_LEVEL_INF);
+
+#define UART_NODE DT_NODELABEL(uart4)
+static const struct device *uart_dev = DEVICE_DT_GET(UART_NODE);
+
+static struct k_sem cmd_sem;
+static struct k_sem cmd_done;
+static struct som_message cmd_reply;
+static uint32_t cmd_pending_id;
+
+static som_notify_cb_t notify_cb;
+static bool som_alive;
+
+static __nocache uint8_t rx_buf[sizeof(struct som_message)];
+static size_t rx_pos;
+
+#define RX_RING_SIZE 512
+static uint8_t rx_ring_buf_data[RX_RING_SIZE];
+static struct ring_buf rx_ring;
+static struct k_sem rx_sem;
+
+K_THREAD_STACK_DEFINE(som_rx_stack, CONFIG_SOM_PROTOCOL_STACK_SIZE);
+static struct k_thread som_rx_thread_data;
+
+static uint8_t som_checksum(const struct som_message *msg)
+{
+	uint8_t cs = 0;
+
+	cs ^= msg->msg_type;
+	cs ^= msg->cmd_type;
+	cs ^= msg->data_len;
+	for (int i = 0; i < msg->data_len; i++) {
+		cs ^= msg->data[i];
+	}
+	return cs;
+}
+
+static void handle_rx_message(const struct som_message *msg)
+{
+	if (msg->header != SOM_FRAME_HEADER || msg->tail != SOM_FRAME_TAIL) {
+		LOG_WRN("Invalid frame header/tail");
+		return;
+	}
+
+	if (som_checksum(msg) != msg->checksum) {
+		LOG_WRN("Checksum mismatch");
+		return;
+	}
+
+	if (msg->msg_type == SOM_MSG_REPLY) {
+		if (msg->task_id == cmd_pending_id) {
+			memcpy(&cmd_reply, msg, sizeof(cmd_reply));
+			k_sem_give(&cmd_done);
+		} else {
+			LOG_WRN("Reply for unknown task_id 0x%08x", msg->task_id);
+		}
+	} else if (msg->msg_type == SOM_MSG_NOTIFY) {
+		LOG_INF("SOM notification: cmd=0x%02x", msg->cmd_type);
+		if (notify_cb) {
+			notify_cb(msg->cmd_type);
+		}
+	} else {
+		LOG_WRN("Unknown message type: 0x%02x", msg->msg_type);
+	}
+}
+
+static void uart_isr_callback(const struct device *dev, void *user_data)
+{
+	uint8_t buf[16];
+	int len;
+
+	while (uart_irq_update(dev) && uart_irq_rx_ready(dev)) {
+		len = uart_fifo_read(dev, buf, sizeof(buf));
+		if (len > 0) {
+			ring_buf_put(&rx_ring, buf, len);
+			k_sem_give(&rx_sem);
+		}
+	}
+}
+
+static int rx_get_byte(uint8_t *byte)
+{
+	while (ring_buf_get(&rx_ring, byte, 1) == 0) {
+		k_sem_take(&rx_sem, K_FOREVER);
+	}
+	return 0;
+}
+
+static void som_rx_thread(void *a, void *b, void *c)
+{
+	uint8_t byte;
+	const uint8_t hdr_bytes[] = {
+		(SOM_FRAME_HEADER >>  0) & 0xFF,
+		(SOM_FRAME_HEADER >>  8) & 0xFF,
+		(SOM_FRAME_HEADER >> 16) & 0xFF,
+		(SOM_FRAME_HEADER >> 24) & 0xFF,
+	};
+	int hdr_match = 0;
+
+	LOG_INF("SOM protocol RX thread started (IRQ mode)");
+
+	while (1) {
+		rx_get_byte(&byte);
+
+		if (rx_pos == 0) {
+			if (byte == hdr_bytes[hdr_match]) {
+				rx_buf[hdr_match] = byte;
+				hdr_match++;
+				if (hdr_match == 4) {
+					rx_pos = 4;
+					hdr_match = 0;
+				}
+			} else {
+				hdr_match = 0;
+			}
+			continue;
+		}
+
+		rx_buf[rx_pos++] = byte;
+
+		if (rx_pos >= sizeof(struct som_message)) {
+			handle_rx_message((const struct som_message *)rx_buf);
+			rx_pos = 0;
+		}
+	}
+}
+
+int som_cmd(uint8_t cmd, void *data, size_t data_len, uint32_t timeout)
+{
+	struct som_message msg = {0};
+	int ret;
+
+	k_sem_take(&cmd_sem, K_FOREVER);
+
+	msg.header = SOM_FRAME_HEADER;
+	msg.task_id = k_uptime_get_32();
+	msg.msg_type = SOM_MSG_REQUEST;
+	msg.cmd_type = cmd;
+	msg.data_len = data_len;
+	if (data && data_len > 0) {
+		memcpy(msg.data, data, MIN(data_len, SOM_FRAME_DATA_MAX));
+	}
+	msg.checksum = som_checksum(&msg);
+	msg.tail = SOM_FRAME_TAIL;
+
+	cmd_pending_id = msg.task_id;
+	k_sem_reset(&cmd_done);
+
+	const uint8_t *tx = (const uint8_t *)&msg;
+
+	for (size_t i = 0; i < sizeof(msg); i++) {
+		uart_poll_out(uart_dev, tx[i]);
+	}
+
+	ret = k_sem_take(&cmd_done, K_MSEC(timeout));
+	if (ret == -EAGAIN) {
+		LOG_DBG("SOM command 0x%02x timed out", cmd);
+		k_sem_give(&cmd_sem);
+		return -ETIMEDOUT;
+	}
+
+	if (cmd_reply.cmd_result != 0) {
+		LOG_WRN("SOM command 0x%02x failed: result=%d", cmd, cmd_reply.cmd_result);
+		k_sem_give(&cmd_sem);
+		return -EIO;
+	}
+
+	if (data && data_len > 0 && cmd_reply.data_len > 0) {
+		memcpy(data, cmd_reply.data, MIN(data_len, cmd_reply.data_len));
+	}
+
+	k_sem_give(&cmd_sem);
+	return 0;
+}
+
+bool som_is_alive(void)
+{
+	return som_alive;
+}
+
+void som_set_alive(bool alive)
+{
+	som_alive = alive;
+}
+
+void som_set_notify_callback(som_notify_cb_t cb)
+{
+	notify_cb = cb;
+}
+
+/* PVT info convenience function */
+int som_get_pvt_info(struct som_pvt_info *info)
+{
+	if (!info) {
+		return -EINVAL;
+	}
+
+	memset(info, 0, sizeof(*info));
+	info->fan_speed = -1;
+
+	return som_cmd(SOM_CMD_PVT_INFO, info, sizeof(*info),
+		       CONFIG_SOM_PROTOCOL_TX_TIMEOUT_MS);
+}
+
+/* Shell commands */
+static int cmd_som_status(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	shell_print(sh, "SOM daemon: %s", som_is_alive() ? "ONLINE" : "OFFLINE");
+	shell_print(sh, "Host power: %s", power_get_state() ? "ON" : "OFF");
+
+	return 0;
+}
+
+static int cmd_som_pvt(const struct shell *sh, size_t argc, char **argv)
+{
+	struct som_pvt_info info;
+	int ret;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	ret = som_get_pvt_info(&info);
+	if (ret < 0) {
+		shell_error(sh, "Failed to get PVT info from SOM: %d", ret);
+		return ret;
+	}
+
+	shell_print(sh, "CPU temp: %d C", info.cpu_temp);
+	shell_print(sh, "NPU temp: %d C", info.npu_temp);
+	if (info.fan_speed >= 0) {
+		shell_print(sh, "Fan speed: %d RPM", info.fan_speed);
+	} else {
+		shell_print(sh, "Fan speed: N/A");
+	}
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_som_cmds,
+	SHELL_CMD(status, NULL, "Show SOM communication status", cmd_som_status),
+	SHELL_CMD(temp, NULL, "Show SOM temperature and fan speed", cmd_som_pvt),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_CMD_REGISTER(som, &sub_som_cmds, "SOM commands", NULL);
+
+/* Keepalive thread */
+#ifdef CONFIG_SOM_KEEPALIVE
+
+K_THREAD_STACK_DEFINE(som_keepalive_stack, CONFIG_SOM_KEEPALIVE_STACK_SIZE);
+static struct k_thread som_keepalive_thread_data;
+
+static void som_keepalive_thread(void *a, void *b, void *c)
+{
+	int fail_count = 0;
+	bool was_alive = false;
+
+	LOG_INF("SOM keepalive thread started");
+
+	while (1) {
+		k_msleep(CONFIG_SOM_KEEPALIVE_INTERVAL_MS);
+
+		if (!power_get_state()) {
+			if (som_alive) {
+				som_set_alive(false);
+				LOG_INF("SOM marked offline (host power off)");
+			}
+			fail_count = 0;
+			continue;
+		}
+
+		int ret = som_cmd(SOM_CMD_BOARD_STATUS, NULL, 0,
+				  CONFIG_SOM_KEEPALIVE_INTERVAL_MS);
+
+		if (ret != 0) {
+			fail_count++;
+			if (fail_count >= CONFIG_SOM_KEEPALIVE_FAIL_THRESHOLD &&
+			    som_alive) {
+				som_set_alive(false);
+				LOG_WRN("SOM keepalive lost after %d failures",
+					fail_count);
+			}
+		} else {
+			if (!som_alive) {
+				LOG_INF("SOM keepalive established");
+			}
+			som_set_alive(true);
+			fail_count = 0;
+		}
+
+		if (was_alive != som_alive) {
+			LOG_INF("SOM daemon state: %s",
+				som_alive ? "ONLINE" : "OFFLINE");
+			was_alive = som_alive;
+		}
+	}
+}
+
+static int som_keepalive_init(void)
+{
+	k_thread_create(&som_keepalive_thread_data, som_keepalive_stack,
+			K_THREAD_STACK_SIZEOF(som_keepalive_stack),
+			som_keepalive_thread,
+			NULL, NULL, NULL,
+			CONFIG_SOM_PROTOCOL_PRIORITY + 1, 0, K_NO_WAIT);
+	k_thread_name_set(&som_keepalive_thread_data, "som_keepalive");
+
+	return 0;
+}
+#endif /* CONFIG_SOM_KEEPALIVE */
+
+int som_protocol_init(void)
+{
+	if (!device_is_ready(uart_dev)) {
+		LOG_ERR("UART4 device not ready");
+		return -ENODEV;
+	}
+
+	k_sem_init(&cmd_sem, 1, 1);
+	k_sem_init(&cmd_done, 0, 1);
+	k_sem_init(&rx_sem, 0, 1);
+	ring_buf_init(&rx_ring, sizeof(rx_ring_buf_data), rx_ring_buf_data);
+	rx_pos = 0;
+
+	uart_irq_callback_set(uart_dev, uart_isr_callback);
+	uart_irq_rx_enable(uart_dev);
+
+	k_thread_create(&som_rx_thread_data, som_rx_stack,
+			K_THREAD_STACK_SIZEOF(som_rx_stack),
+			som_rx_thread,
+			NULL, NULL, NULL,
+			CONFIG_SOM_PROTOCOL_PRIORITY, 0, K_NO_WAIT);
+	k_thread_name_set(&som_rx_thread_data, "som_protocol");
+
+#ifdef CONFIG_SOM_KEEPALIVE
+	som_keepalive_init();
+#endif
+
+	LOG_INF("SOM protocol initialized (UART4)");
+
+	return 0;
+}

--- a/src/eswin/som_protocol.h
+++ b/src/eswin/som_protocol.h
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: © 2026 Red Hat, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef __SOM_PROTOCOL_H__
+#define __SOM_PROTOCOL_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define SOM_FRAME_HEADER	0xA55AAA55
+#define SOM_FRAME_TAIL		0xBDBABDBA
+#define SOM_FRAME_DATA_MAX	250
+
+enum som_msg_type {
+	SOM_MSG_REQUEST  = 0x01,
+	SOM_MSG_REPLY    = 0x02,
+	SOM_MSG_NOTIFY   = 0x03,
+};
+
+enum som_cmd_type {
+	SOM_CMD_POWER_OFF    = 0x01,
+	SOM_CMD_REBOOT       = 0x02,
+	SOM_CMD_BOARD_INFO   = 0x03,
+	SOM_CMD_CONTROL_LED  = 0x04,
+	SOM_CMD_PVT_INFO     = 0x05,
+	SOM_CMD_BOARD_STATUS = 0x06,
+	SOM_CMD_POWER_INFO   = 0x07,
+	SOM_CMD_RESTART      = 0x08,
+};
+
+struct som_message {
+	uint32_t header;
+	uint32_t task_id;
+	uint8_t  msg_type;
+	uint8_t  cmd_type;
+	uint8_t  cmd_result;
+	uint8_t  data_len;
+	uint8_t  data[SOM_FRAME_DATA_MAX];
+	uint8_t  checksum;
+	uint32_t tail;
+} __packed;
+
+struct som_pvt_info {
+	int32_t cpu_temp;
+	int32_t npu_temp;
+	int32_t fan_speed;
+} __packed;
+
+struct som_power_info {
+	uint32_t consumption;
+	uint32_t current;
+	uint32_t voltage;
+} __packed;
+
+#ifdef CONFIG_SOM_PROTOCOL
+int som_protocol_init(void);
+int som_cmd(uint8_t cmd, void *data, size_t data_len, uint32_t timeout);
+int som_get_pvt_info(struct som_pvt_info *info);
+bool som_is_alive(void);
+void som_set_alive(bool alive);
+typedef void (*som_notify_cb_t)(uint8_t cmd_type);
+void som_set_notify_callback(som_notify_cb_t cb);
+#else
+static inline int som_protocol_init(void) { return 0; }
+static inline int som_cmd(uint8_t c, void *d, size_t l, uint32_t t) { return -ENOTSUP; }
+static inline int som_get_pvt_info(struct som_pvt_info *i) { return -ENOTSUP; }
+static inline bool som_is_alive(void) { return false; }
+static inline void som_set_alive(bool alive) { }
+static inline void som_set_notify_callback(void (*cb)(uint8_t)) { }
+#endif
+
+#endif


### PR DESCRIPTION
P550-specific hardware integration for the ESWIN EIC7700X SoC:

SOM protocol (src/eswin/som_protocol):
- UART4 binary protocol for BMC-SoC communication
- Keepalive, PVT info (CPU/NPU temps), board status
- Host online/offline state tracking

Graceful power management:
- Shutdown/restart via SOM protocol commands
- Configurable timeouts with forced fallback
- Host daemon does not ACK until shutdown completes (BMC timeout is the safety net)

Boot mode selection (src/eswin/bootsel):
- BOOT_SEL[3:0] GPIO control for SoC boot source
- Hardware mode (DIP switch) and software override

Board identity (src/eswin/board_identity):
- EEPROM-based serial number and MAC address storage
- I2C mux and write-protect control

Host-side SOM daemon (boards/.../host-somd/):
- Responds to BMC keepalive and PVT queries
- systemd service unit
- Test suite (10 tests)