### PR TITLE
Initial XIAO esp32c6 support for K3 com260

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,15 @@ jobs:
 
     strategy:
       matrix:
-        board: [nucleo_f767zi, hifive_premier_p550_mcu, qemu_cortex_m3]
+        include:
+          - board: nucleo_f767zi
+            name: nucleo_f767zi
+          - board: hifive_premier_p550_mcu
+            name: hifive_premier_p550_mcu
+          - board: qemu_cortex_m3
+            name: qemu_cortex_m3
+          - board: xiao_esp32c6/esp32c6/hpcore
+            name: xiao_esp32c6
 
     env:
       CMAKE_PREFIX_PATH: /opt/toolchains
@@ -78,8 +86,13 @@ jobs:
           # Update modules (fetches Zephyr kernel, HAL_STM32, etc.)
           west update --path-cache /repo-cache/zephyrproject --narrow -o=--depth=10000 -o=--tags
 
+      - name: Fetch Espressif Blobs
+        if: ${{ matrix.name == 'xiao_esp32c6' }}
+        working-directory: workspace
+        run: west blobs fetch hal_espressif
+
       - name: Build WallaBMC (sysbuild boards)
-        if: ${{ matrix.board != 'qemu_cortex_m3' }}
+        if: ${{ matrix.name != 'qemu_cortex_m3' && matrix.name != 'xiao_esp32c6' }}
         working-directory: workspace
         run: |
           west build --sysbuild -p always -b $BOARD ../wallabmc
@@ -92,18 +105,19 @@ jobs:
           mv build/wallabmc/zephyr/zephyr.signed.hex build/wallabmc.signed.hex
           mv build/wallabmc/zephyr/zephyr.signed.bin build/wallabmc.signed.bin
 
-      - name: Build WallaBMC (QEMU image)
-        if: ${{ matrix.board == 'qemu_cortex_m3' }}
+      - name: Build WallaBMC (no-sysbuild boards)
+        if: ${{ matrix.name == 'qemu_cortex_m3' || matrix.name == 'xiao_esp32c6' }}
         working-directory: workspace
         run: |
-          # QEMU build does not do sysbuild
+          # qemu_cortex_m3 and xiao_esp32c6 are listed in NO_SYSBUILD_BOARDS;
+          # xiao uses Espressif Simple Boot rather than MCUboot.
           west build -p always -b $BOARD ../wallabmc
 
-      - name: Upload Board Firmware
-        if: ${{ matrix.board != 'qemu_cortex_m3' }}
+      - name: Upload Sysbuild Firmware
+        if: ${{ matrix.name != 'qemu_cortex_m3' && matrix.name != 'xiao_esp32c6' }}
         uses: actions/upload-artifact@v6
         with:
-          name: wallabmc-firmware-${{ matrix.board }}
+          name: wallabmc-firmware-${{ matrix.name }}
           path: |
             workspace/build/mcuboot.hex
             workspace/build/mcuboot.bin
@@ -114,11 +128,11 @@ jobs:
             workspace/build/wallabmc.signed.hex
             workspace/build/wallabmc.signed.bin
 
-      - name: Upload QEMU Firmware
-        if: ${{ matrix.board == 'qemu_cortex_m3' }}
+      - name: Upload No-Sysbuild Firmware
+        if: ${{ matrix.name == 'qemu_cortex_m3' || matrix.name == 'xiao_esp32c6' }}
         uses: actions/upload-artifact@v6
         with:
-          name: wallabmc-firmware-${{ matrix.board }}
+          name: wallabmc-firmware-${{ matrix.name }}
           path: |
             workspace/build/zephyr/zephyr.bin
             workspace/build/zephyr/zephyr.elf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,8 @@ if(CONFIG_PERSISTENT_STORAGE)
     include(${ZEPHYR_BASE}/cmake/modules/extensions.cmake)
     FILE(GLOB flash_driver ${ZEPHYR_BASE}/drivers/flash/flash_stm32*.c)
     zephyr_code_relocate(FILES ${flash_driver} LOCATION RAM)
+  elseif(CONFIG_SOC_FLASH_ESP32)
+    # ESP32 flash driver disables the XIP cache internally; no relocation needed.
   else()
     message(FATAL_ERROR "flash storage handling is not defined for this platform")
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,11 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(wallabmc)
 
-if(BOARD STREQUAL "qemu_cortex_m3")
+# Boards that use their SoC's native bootloader and skip mcuboot/sysbuild.
+set(NO_SYSBUILD_BOARDS "qemu_cortex_m3" "xiao_esp32c6")
+if(BOARD IN_LIST NO_SYSBUILD_BOARDS)
 	if(SYSBUILD)
-		message(FATAL_ERROR "qemu_cortex_m3 must NOT be built with sysbuild (e.g., no --sysbuild argument)")
+		message(FATAL_ERROR "${BOARD} must NOT be built with sysbuild (e.g., no --sysbuild argument)")
 	endif()
 else()
 	if(NOT SYSBUILD)
@@ -65,6 +67,10 @@ target_sources_ifdef(CONFIG_APP_SENSORS app PRIVATE
 
 target_sources_ifdef(CONFIG_APP_NTP app PRIVATE
 	src/ntp.c
+)
+
+target_sources_ifdef(CONFIG_APP_WIFI app PRIVATE
+	src/wifi.c
 )
 
 target_sources_ifdef(CONFIG_HTTP_SERVER app PRIVATE

--- a/Kconfig
+++ b/Kconfig
@@ -343,9 +343,10 @@ config PERSISTENT_STORAGE
 	select FLASH
 	select FLASH_MAP
 	# select FLASH_SHELL if SHELL # ~4kB flash
-	# Writing internal flash that is used for XIP requires
-	# that the flash driver is relocated into RAM.
-	select CODE_DATA_RELOCATION_SRAM
+	# STM32 internal flash is also XIP, so the flash driver has to be
+	# relocated into RAM to write it. ESP32's flash driver disables
+	# the XIP cache internally, so no relocation is needed there.
+	select CODE_DATA_RELOCATION_SRAM if SOC_FLASH_STM32
 	# XXX: May need to enable these, or disable IRQs in the flash
 	# erase and program functions while flash is being written.
 	# select SRAM_VECTOR_TABLE

--- a/Kconfig
+++ b/Kconfig
@@ -393,8 +393,8 @@ config APP_CONSOLE_LOGGER
 	bool "Console logger (capture host console uart)"
 	default y
 	select SERIAL
-	select SERIAL_SUPPORT_ASYNC
-	select UART_ASYNC_API
+	select SERIAL_SUPPORT_INTERRUPT
+	select UART_INTERRUPT_DRIVEN
 
 if APP_CONSOLE_LOGGER
 config APP_CONSOLE_LOG_SIZE

--- a/Kconfig
+++ b/Kconfig
@@ -385,6 +385,14 @@ config APP_HOST_POWER_FORCE_OFF_MS
 	default 6000
 	depends on APP_HOST_POWER_PULSE
 
+config APP_WIFI
+	bool "Connect to Wi-Fi at boot"
+	default y if WIFI
+	depends on WIFI
+	select WIFI_CREDENTIALS
+	select WIFI_CREDENTIALS_STATIC
+	select NET_L2_WIFI_MGMT
+
 config JTAG
 	bool "JTAG support"
 	depends on $(dt_path_enabled,/jtag)

--- a/Kconfig
+++ b/Kconfig
@@ -386,12 +386,20 @@ config APP_HOST_POWER_FORCE_OFF_MS
 	depends on APP_HOST_POWER_PULSE
 
 config APP_WIFI
-	bool "Connect to Wi-Fi at boot"
+	bool "Connect to Wi-Fi at boot from BMC config"
 	default y if WIFI
 	depends on WIFI
-	select WIFI_CREDENTIALS
-	select WIFI_CREDENTIALS_STATIC
 	select NET_L2_WIFI_MGMT
+	help
+	  Bring Wi-Fi up at boot using the SSID and password the operator
+	  set via the `wifi connect` shell command (persisted in NVS). To
+	  bake an SSID into the image as a fallback for first-boot
+	  bring-up without console access, also pass
+	  -DCONFIG_WIFI_CREDENTIALS=y
+	  -DCONFIG_WIFI_CREDENTIALS_STATIC=y
+	  -DCONFIG_WIFI_CREDENTIALS_STATIC_SSID='"..."'
+	  -DCONFIG_WIFI_CREDENTIALS_STATIC_PASSWORD='"..."'
+	  on the cmake line.
 
 config JTAG
 	bool "JTAG support"

--- a/Kconfig
+++ b/Kconfig
@@ -364,6 +364,27 @@ config POWEROFF
 	bool
 	default y if HAS_POWEROFF
 
+config APP_HOST_POWER_PULSE
+	bool "Host power pin uses momentary-button (pulse) semantics"
+	default n
+	help
+	  When set, `power on` / `power off` / `power force-off` pulse the
+	  host power GPIO instead of holding it at a sustained level. Use
+	  for boards with an ATX-style momentary power button input.
+
+	  Without this, the GPIO is driven to a sustained level (the
+	  legacy nucleo LED-as-power-stand-in behaviour).
+
+config APP_HOST_POWER_PULSE_MS
+	int "Short-press duration for power on/off (ms)"
+	default 200
+	depends on APP_HOST_POWER_PULSE
+
+config APP_HOST_POWER_FORCE_OFF_MS
+	int "Long-press duration for power force-off (ms)"
+	default 6000
+	depends on APP_HOST_POWER_PULSE
+
 config JTAG
 	bool "JTAG support"
 	depends on $(dt_path_enabled,/jtag)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ WallaBMC currently supports the following hardware platforms:
 | --- | --- | --- |
 | **SiFive HiFive Premier P550 MCU** | hifive_premier_p550_mcu | RISC-V based platform |
 | **STM32 Nucleo F767ZI** | nucleo_f767zi | ARM Cortex-M7 development board (standalone, no host CPU) |
+| **Seeed Studio XIAO ESP32-C6** | xiao_esp32c6/esp32c6/hpcore | RISC-V, Wi-Fi 6, on a 21×17.5 mm board with USB-C; BMC console over USB Serial/JTAG (see [below](#seeed-xiao-esp32-c6)) |
 | **qemu** | qemu_cortex_m3 | see [run_qemu_ci.py](scripts/run_qemu_ci.py) |
 
 ### Screenshot
@@ -34,6 +35,87 @@ WallaBMC currently supports the following hardware platforms:
 The main page of the web interface is shown below, click to enlarge.
 
 [![Web UI screenshot](img/web-ui-thumbnail.png)](img/web-ui.png)
+
+### Seeed XIAO ESP32-C6
+
+The ESP32-C6 (RISC-V, Wi-Fi 6) on Seeed Studio's 21×17.5 mm XIAO form
+factor with a USB-C connector. The BMC console runs over the SoC's
+built-in USB Serial/JTAG (the XIAO's USB-C port), so a separate UART
+(UART1) is free for the host serial bridge. Only three GPIOs on the
+XIAO connector are needed for host control; the host UART pads stay
+clear of the default I2C bus (D4/D5) and SPI bus (D8/D9/D10) so those
+remain free for other uses.
+
+#### Wiring
+
+Four wires between the XIAO ESP32-C6 and the host board:
+
+| XIAO pin | GPIO | Direction | Host signal | Notes |
+| --- | --- | --- | --- | --- |
+| D0 | GPIO0 | out | host UART RX | UART1 TX — host serial console (115200 8N1) |
+| D3 | GPIO21 | in | host UART TX | UART1 RX — host serial console |
+| D2 | GPIO2 | out (open-drain) | SYSRESET# input | Active-low, 1 s low pulse on `reset` / `power force-restart` |
+| GND | — | — | GND | Common reference, required |
+
+> **Voltage warning.** ESP32-C6 GPIOs are **not** 5 V tolerant. The
+> SYSRESET# pin is driven open-drain, so it only sinks — the host's
+> internal pull-up sets the un-asserted level. If the host holds that
+> line above 3.3 V when un-asserted, add a small N-MOSFET (gate = ESP32
+> GPIO, drain = host pin, source = GND) between them. The UART1 RX
+> line (D3 / GPIO21) sees the host's TX voltage directly; if the host
+> UART runs above 3.3 V, level-shift it.
+
+#### Build and flash
+
+The XIAO uses Espressif's built-in Simple Boot rather than MCUboot,
+so the build skips ``--sysbuild``. Plug the XIAO into your build host
+over USB-C — the same USB cable provides power, flashes the firmware,
+and carries the BMC console:
+
+```
+# One-time: fetch the Espressif Wi-Fi/PHY binary blobs.
+west blobs fetch hal_espressif
+
+cd zephyr
+west build -b xiao_esp32c6/esp32c6/hpcore ../wallabmc --pristine \
+    -- -DCONFIG_DEFAULT_ADMIN_PASSWORD='"admin"'
+west flash
+```
+
+The first time you boot a freshly flashed image with no baked-in
+SSID, set the Wi-Fi from the BMC console (USB-CDC over the XIAO's
+USB-C port):
+
+```
+wifi connect your-ssid your-password
+```
+
+The credentials are persisted in NVS and reused on every subsequent
+boot. To bake an SSID into the image instead (for first-boot bring-up
+without console access), add to the cmake line:
+
+```
+    -DCONFIG_WIFI_CREDENTIALS=y \
+    -DCONFIG_WIFI_CREDENTIALS_STATIC=y \
+    -DCONFIG_WIFI_CREDENTIALS_STATIC_SSID='"your-ssid"' \
+    -DCONFIG_WIFI_CREDENTIALS_STATIC_PASSWORD='"your-password"' \
+```
+
+On boot the BMC associates to Wi-Fi, picks up a DHCPv4 lease, and
+logs the address on the BMC console. Browse to ``http://<that-ip>/``
+for the web UI; the BMC shell is available there, on the BMC USB-CDC
+console, or (once the host is up) the host UART console is reachable
+via the web UI's host-console terminal and TCP port 22.
+
+#### Host control from the shell
+
+```
+power on              # 200 ms press on GPIO1 (if BMC believes host is off)
+power off             # 200 ms press on GPIO1 (if BMC believes host is on)
+power force-off       # 6 s press on GPIO1
+power force-restart   # 1 s low pulse on GPIO2 (SYSRESET#)
+reset                 # alias for power force-restart
+```
 
 ## Using
 

--- a/boards/xiao_esp32c6_hpcore.conf
+++ b/boards/xiao_esp32c6_hpcore.conf
@@ -1,0 +1,74 @@
+# Initial Seeed XIAO ESP32-C6 port: Wi-Fi + HTTP web UI + USB-CDC console.
+
+# Disable features that require extra hardware not wired up on this devkit yet.
+CONFIG_RTC=n
+CONFIG_APP_NTP=n
+CONFIG_APP_SENSORS=n
+# Host serial bridge: UART1 on GPIO0 TX / GPIO21 RX (the XIAO's D0/D3)
+# captured into a ring buffer, exposed via TCP port 22 (CONSOLE_BRIDGE)
+# and the web UI terminal. The BMC's own console runs over the SoC's
+# built-in USB Serial/JTAG (the XIAO's USB-C connector). The console
+# logger uses UART async API which requires GDMA on the C6.
+CONFIG_APP_CONSOLE_LOGGER=y
+CONFIG_CONSOLE_BRIDGE=y
+CONFIG_APP_WEB_TERMINAL_HOST_SERIAL=y
+CONFIG_DMA=y
+
+# Host power button on GPIO1 (D1) — `power on/off` does a short press,
+# `power force-off` does a long press.
+CONFIG_APP_HOST_POWER_PULSE=y
+
+# Plain HTTP only for first bring-up — mbedtls/TLS adds heap pressure we
+# can revisit once the basics work.
+CONFIG_APP_HTTPS=n
+
+# Wi-Fi station + WPA supplicant. Credentials are normally set at
+# runtime via the `wifi connect <ssid> <password>` shell command and
+# persisted in NVS, so the build does not need an SSID baked in. To
+# bake one in for first-boot bring-up without console access, pass
+#   -DCONFIG_WIFI_CREDENTIALS=y
+#   -DCONFIG_WIFI_CREDENTIALS_STATIC=y
+#   -DCONFIG_WIFI_CREDENTIALS_STATIC_SSID='"..."'
+#   -DCONFIG_WIFI_CREDENTIALS_STATIC_PASSWORD='"..."'
+# on the cmake line.
+CONFIG_WIFI=y
+CONFIG_NET_L2_WIFI_MGMT=y
+# Reconnect automatically if the AP boots us or the link drops. Without
+# this the BMC stays offline after any transient disassociation.
+CONFIG_ESP32_WIFI_STA_RECONNECT=y
+# More Wi-Fi driver RX buffers: the default 10 static / 32 dynamic was
+# enough for idle traffic but dropped frames under bursty HTTP load.
+CONFIG_ESP32_WIFI_STATIC_RX_BUFFER_NUM=16
+CONFIG_ESP32_WIFI_DYNAMIC_RX_BUFFER_NUM=64
+
+# Wi-Fi/network stack sizing. Trimmed from the upstream samples/net/wifi/shell
+# defaults to free SRAM for the heap (Redfish JSON allocations were failing
+# under concurrent requests).
+CONFIG_MAIN_STACK_SIZE=4096
+CONFIG_SHELL_STACK_SIZE=4096
+CONFIG_NET_TX_STACK_SIZE=2048
+CONFIG_NET_RX_STACK_SIZE=2048
+CONFIG_NET_MGMT_EVENT_QUEUE_TIMEOUT=5000
+CONFIG_NET_MGMT_EVENT_QUEUE_SIZE=16
+
+# TCP recv window + net buffers / contexts. The aggressive trim that fit
+# the initial bring-up made Wi-Fi flaky under load (RX drops, stalled
+# Redfish responses); these are still well below the upstream wifi-shell
+# defaults but big enough to ride out short bursts.
+CONFIG_NET_TCP_MAX_RECV_WINDOW_SIZE=8192
+CONFIG_NET_BUF_RX_COUNT=40
+CONFIG_NET_BUF_TX_COUNT=40
+CONFIG_NET_PKT_RX_COUNT=16
+CONFIG_NET_PKT_TX_COUNT=16
+# Total TCP/UDP sockets. Has to cover HTTP_SERVER_MAX_CLIENTS + listen
+# socket + the console-bridge TCP server + its current client + DHCP.
+CONFIG_NET_MAX_CONTEXTS=12
+CONFIG_HTTP_SERVER_MAX_CLIENTS=6
+
+# Heap for Wi-Fi / TCP buffers and Redfish JSON. ~240 KB SRAM is free in
+# the static layout so we can afford a much larger pool than the initial
+# bring-up value of 80 KB.
+CONFIG_HEAP_MEM_POOL_SIZE=163840
+
+# Provides random for WPA supplicant
+CONFIG_TEST_RANDOM_GENERATOR=y

--- a/boards/xiao_esp32c6_hpcore.overlay
+++ b/boards/xiao_esp32c6_hpcore.overlay
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: © 2025-2026 Tenstorrent USA, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Seeed Studio XIAO ESP32-C6 port.
+ *
+ * The BMC console / shell is the SoC's built-in USB Serial/JTAG (the
+ * XIAO's USB-C connector); the board DTS already routes
+ * zephyr,console + zephyr,shell-uart there. The host serial bridge
+ * uses UART1 on D0 (GPIO0) / D3 (GPIO21) — both pads are otherwise
+ * unused on the XIAO connector and stay clear of the default I2C
+ * (D4/D5) and SPI (D8/D9/D10) bus pads.
+ *
+ *   D0 = GPIO0  = UART1 TX (out to host RX)
+ *   D3 = GPIO21 = UART1 RX (in from host TX)
+ *   D1 = GPIO1  = PWRBTN#   (open-drain, active-low)
+ *   D2 = GPIO2  = SYSRESET# (open-drain, active-low)
+ *   Common GND with the host board.
+ *
+ * /jtag node omitted -> CONFIG_JTAG auto-disabled via dt_path_enabled().
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c6-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c6-gpio-sigmap.h>
+
+/ {
+	host_power {
+		compatible = "gpio-leds";
+
+		/*
+		 * Host power button and system reset. Open-drain + active-low:
+		 * the ESP32 only ever sinks current; the un-asserted level is
+		 * set by the host (e.g. K3 internal pull-up) or, with no host
+		 * connected, by the ESP32 internal pull-up that GPIO_PULL_UP
+		 * enables here -- so the line idles high either way, including
+		 * for bench probing with an oscilloscope. host_pwrbtn is pulsed
+		 * by power.c when CONFIG_APP_HOST_POWER_PULSE=y. host_sysreset
+		 * is pulsed by `reset` / `power force-restart` (power_reset())
+		 * for ~1 s.
+		 */
+		host_pwrbtn: host_pwrbtn {
+			gpios = <&gpio0 1 (GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
+		};
+		host_sysreset: host_sysreset {
+			gpios = <&gpio0 2 (GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
+		};
+	};
+
+	aliases {
+		host-console-uart = &uart1;
+		power-gpio-1 = &host_pwrbtn;
+		reset-gpio-1 = &host_sysreset;
+		status-led = &yellow_led;
+	};
+};
+
+&pinctrl {
+	uart1_default: uart1_default {
+		group1 {
+			pinmux = <UART1_TX_GPIO0>;
+			output-high;
+			drive-push-pull;
+		};
+		group2 {
+			pinmux = <UART1_RX_GPIO21>;
+			bias-pull-up;
+		};
+	};
+};
+
+&dma {
+	status = "okay";
+};
+
+&uart1 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart1_default>;
+	pinctrl-names = "default";
+	/* GDMA channels for async TX / RX. Channels 2,3 are reserved by
+	 * i2s in the SoC DTS (i2s itself is disabled in this build).
+	 */
+	dmas = <&dma 0>, <&dma 1>;
+	dma-names = "tx", "rx";
+};

--- a/src/config.c
+++ b/src/config.c
@@ -100,7 +100,8 @@ static ssize_t __config_write(uint16_t id, const void *buf, size_t size)
 {
 	if (config_use_fs)
 		return fs_key_write(id, buf, size);
-	return -ENODEV;
+	/* No persistent storage; caller's RAM copy is the only source of truth. */
+	return size;
 }
 
 #define config_read(id, var)				\

--- a/src/config.c
+++ b/src/config.c
@@ -27,6 +27,10 @@ LOG_MODULE_REGISTER(wallabmc_config, LOG_LEVEL_INF);
 
 #define MAX_NTP_SERVER_LEN 40
 
+/* 802.11 caps SSID at 32 bytes; WPA-PSK passphrase is 8..63 chars. */
+#define MAX_WIFI_SSID_LEN 32
+#define MAX_WIFI_PASSWORD_LEN 63
+
 /* Incrementing this allows a flag-day upgrade, but avoid doing it. */
 #define CFG_CURRENT_VERSION 3
 
@@ -41,6 +45,8 @@ enum config_id {
 	CFG_BMC_USE_NTP = 8,			/* uint8_t */
 	CFG_BMC_NTP_SERVER = 9,		/* C string */
 	CFG_HOST_AUTO_POWERON = 10,		/* uint8_t */
+	CFG_WIFI_SSID = 11,			/* C string */
+	CFG_WIFI_PASSWORD = 12,		/* C string */
 	/*
 	 * Add field IDs in increasing order and do not reuse deprecated
 	 * ones. Do not change meaning but add new and deprecate old.
@@ -60,6 +66,8 @@ struct config_data {
 	char bmc_ntp_server[MAX_NTP_SERVER_LEN + 1]; /* NULL terminated */
 	uint32_t bmc_default_ip4_nm;
 	uint32_t bmc_default_ip4_gw;
+	char wifi_ssid[MAX_WIFI_SSID_LEN + 1];      /* NULL terminated, empty = unset */
+	char wifi_password[MAX_WIFI_PASSWORD_LEN + 1]; /* NULL terminated */
 };
 
 BUILD_ASSERT(strlen(CONFIG_DEFAULT_ADMIN_PASSWORD) <= MAX_PW_LEN);
@@ -172,6 +180,69 @@ bool config_bmc_use_ntp(void)
 const char *config_bmc_ntp_server(void)
 {
 	return config_data.bmc_ntp_server;
+}
+
+const char *config_wifi_ssid(void)
+{
+	return config_data.wifi_ssid;
+}
+
+const char *config_wifi_password(void)
+{
+	return config_data.wifi_password;
+}
+
+int config_wifi_set(const char *ssid, const char *password)
+{
+	int rc;
+
+	if (ssid == NULL || password == NULL)
+		return -EINVAL;
+	if (strlen(ssid) == 0 || strlen(ssid) > MAX_WIFI_SSID_LEN) {
+		LOG_ERR("Invalid Wi-Fi SSID length");
+		return -EINVAL;
+	}
+	if (strlen(password) > MAX_WIFI_PASSWORD_LEN) {
+		LOG_ERR("Wi-Fi password too long (max %d)", MAX_WIFI_PASSWORD_LEN);
+		return -EINVAL;
+	}
+
+	strlcpy(config_data.wifi_ssid, ssid, sizeof(config_data.wifi_ssid));
+	strlcpy(config_data.wifi_password, password, sizeof(config_data.wifi_password));
+
+	rc = config_write_str(CFG_WIFI_SSID, config_data.wifi_ssid);
+	if (rc < 0) {
+		LOG_ERR("Configuration could not be saved (err=%d)", rc);
+		return rc;
+	}
+	rc = config_write_str(CFG_WIFI_PASSWORD, config_data.wifi_password);
+	if (rc < 0) {
+		LOG_ERR("Configuration could not be saved (err=%d)", rc);
+		return rc;
+	}
+
+	return 0;
+}
+
+int config_wifi_clear(void)
+{
+	int rc;
+
+	config_data.wifi_ssid[0] = '\0';
+	config_data.wifi_password[0] = '\0';
+
+	rc = config_write_str(CFG_WIFI_SSID, config_data.wifi_ssid);
+	if (rc < 0) {
+		LOG_ERR("Configuration could not be saved (err=%d)", rc);
+		return rc;
+	}
+	rc = config_write_str(CFG_WIFI_PASSWORD, config_data.wifi_password);
+	if (rc < 0) {
+		LOG_ERR("Configuration could not be saved (err=%d)", rc);
+		return rc;
+	}
+
+	return 0;
 }
 
 #if defined(CONFIG_APP_HTTPS_PSK)
@@ -847,6 +918,20 @@ int config_init(void)
 		config_data.host_auto_poweron = 0;
 		config_write(CFG_HOST_AUTO_POWERON, config_data.host_auto_poweron);
 	}
+
+	/*
+	 * Wi-Fi credentials default to the empty string when no value has
+	 * been set via `wifi connect`. wifi.c treats empty SSID as "fall back
+	 * to the compile-time static credential", so don't write anything
+	 * back here -- the absence of a key is the signal.
+	 */
+	rc = config_read_str(CFG_WIFI_SSID, config_data.wifi_ssid);
+	if (rc < 0)
+		config_data.wifi_ssid[0] = '\0';
+
+	rc = config_read_str(CFG_WIFI_PASSWORD, config_data.wifi_password);
+	if (rc < 0)
+		config_data.wifi_password[0] = '\0';
 
 	return 0;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -26,4 +26,8 @@ bool config_host_auto_poweron(void);
 int config_host_auto_poweron_set(bool on);
 const char *config_bmc_admin_password(void);
 bool config_bmc_https_psk(const char **psk, int *psk_len);
+const char *config_wifi_ssid(void);
+const char *config_wifi_password(void);
+int config_wifi_set(const char *ssid, const char *password);
+int config_wifi_clear(void);
 #endif

--- a/src/console_logger.c
+++ b/src/console_logger.c
@@ -9,18 +9,12 @@
 LOG_MODULE_REGISTER(console_logger, LOG_LEVEL_INF);
 
 #include <zephyr/spinlock.h>
-#include <zephyr/posix/fcntl.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/gpio.h>
-#include <zephyr/net/socket.h>
 #include <errno.h>
-#include <unistd.h>
-#include <sys/socket.h>
 #include <string.h>
 
 #include "synch.h"
-
-#define UART_RX_DELAY_US 50000
 
 #define UART_NODE DT_ALIAS(host_console_uart)
 static const struct device *uart_dev = DEVICE_DT_GET(UART_NODE);
@@ -34,107 +28,70 @@ static const struct gpio_dt_spec host_console_uart_muxsel_gpio = GPIO_DT_SPEC_GE
 #endif
 
 /*
- * Chunk size of the circular console log that we give to UART RX DMA. This does not
- * consume any memory (it's just a chunk of the console log buffer region), but it
- * does make the oldest part of the log unavailable so should not be a big fraction of
- * the console log size. Two chunks will be in-flight at any time due to the pipelined
- * buffer allocation in the uart code, so this uses up to 1/8th of the log space.
+ * Max bytes to drain from the UART RX FIFO per IRQ. Larger keeps each
+ * IRQ self-contained at higher line rates; smaller bounds the time
+ * spent in the handler. 64 is comfortable at 115200 (~5.6 ms of bytes).
  */
-#define UART_RX_BUF_SIZE (CONFIG_APP_CONSOLE_LOG_SIZE / 16)
-
-/*
- * TX buf is the size of the DMA buffer we can give to the UART.
- * Probably does not have to be this large, most interactive input
- * will be a handful of characters.
- */
-#define UART_TX_BUF_SIZE 32
+#define UART_RX_DRAIN_CHUNK 64
 
 struct console_log {
 	const struct device *uart;
-	uint64_t allocated;
 	uint64_t received;
 	int size;
 	struct k_spinlock rx_lock;
-	struct k_sem tx_sem;
+
+	/* TX is serialized by tx_mutex; tx_done is given by the IRQ when
+	 * the pending buffer has been fully pushed to the FIFO.
+	 */
+	struct k_mutex tx_mutex;
+	struct k_sem tx_done;
+	const uint8_t *tx_buf;
+	size_t tx_len;
+	size_t tx_pos;
+
 	uint8_t *log_buffer;
-	uint8_t *tx_buffer;
 };
 
 static struct console_log host_console_log;
 
-/* DMA'ed to/from by the UART, so must be __nocache */
-static __nocache uint8_t log_buffer[CONFIG_APP_CONSOLE_LOG_SIZE];
-static __nocache uint8_t tx_buffer[UART_TX_BUF_SIZE];
+static uint8_t log_buffer[CONFIG_APP_CONSOLE_LOG_SIZE];
 
-static void uart_rx_ready(const struct device *dev, struct uart_event *evt, struct console_log *log)
-{
-	k_spinlock_key_t key;
-
-	key = k_spin_lock(&log->rx_lock);
-	log->received += evt->data.rx.len;
-	k_spin_unlock(&log->rx_lock, key);
-
-	k_event_post(&events, EVENT_CONSOLE_LOG_DATA);
-}
-
-static void uart_rx_allocate(const struct device *dev, struct console_log *log)
-{
-	int off;
-	int ret;
-	k_spinlock_key_t key;
-
-	key = k_spin_lock(&log->rx_lock);
-	off = log->allocated % log->size;
-	log->allocated += UART_RX_BUF_SIZE;
-	k_spin_unlock(&log->rx_lock, key);
-
-	ret = uart_rx_buf_rsp(dev, log->log_buffer + off, UART_RX_BUF_SIZE);
-	if (ret < 0)
-		LOG_ERR("Failed to supply buffer UART RX: %d", ret);
-}
-
-static void uart_rx_start(const struct device *dev, struct console_log *log)
-{
-	int off;
-	int ret;
-	k_spinlock_key_t key;
-
-	key = k_spin_lock(&log->rx_lock);
-	off = log->allocated % log->size;
-	log->allocated += UART_RX_BUF_SIZE;
-	k_spin_unlock(&log->rx_lock, key);
-
-	ret = uart_rx_enable(dev, log->log_buffer + off, UART_RX_BUF_SIZE, UART_RX_DELAY_US);
-	if (ret < 0)
-		LOG_ERR("Failed to enable UART RX: %d", ret);
-}
-
-static void uart_callback(const struct device *dev, struct uart_event *evt, void *user_data)
+static void uart_isr_cb(const struct device *dev, void *user_data)
 {
 	struct console_log *log = user_data;
 
-	switch (evt->type) {
-	case UART_RX_RDY:
-		uart_rx_ready(dev, evt, log);
-		break;
+	while (uart_irq_update(dev) > 0 && uart_irq_is_pending(dev)) {
+		if (uart_irq_rx_ready(dev)) {
+			uint8_t tmp[UART_RX_DRAIN_CHUNK];
+			int n = uart_fifo_read(dev, tmp, sizeof(tmp));
 
-	case UART_RX_DISABLED:
-		uart_rx_start(dev, log);
-		break;
+			if (n > 0) {
+				k_spinlock_key_t key = k_spin_lock(&log->rx_lock);
+				size_t off = log->received % log->size;
+				size_t first = MIN((size_t)n, (size_t)log->size - off);
 
-	case UART_RX_BUF_REQUEST:
-		uart_rx_allocate(dev, log);
-		break;
+				memcpy(log->log_buffer + off, tmp, first);
+				if (first < (size_t)n)
+					memcpy(log->log_buffer, tmp + first, (size_t)n - first);
+				log->received += (size_t)n;
+				k_spin_unlock(&log->rx_lock, key);
 
-	case UART_RX_STOPPED:
-		break;
+				k_event_post(&events, EVENT_CONSOLE_LOG_DATA);
+			}
+		}
 
-	case UART_TX_DONE:
-		k_sem_give(&log->tx_sem);
-		break;
-
-	default:
-		break;
+		if (uart_irq_tx_ready(dev)) {
+			if (log->tx_pos < log->tx_len) {
+				int n = uart_fifo_fill(dev, log->tx_buf + log->tx_pos,
+						       log->tx_len - log->tx_pos);
+				if (n > 0)
+					log->tx_pos += n;
+			}
+			if (log->tx_pos >= log->tx_len) {
+				uart_irq_tx_disable(dev);
+				k_sem_give(&log->tx_done);
+			}
+		}
 	}
 }
 
@@ -156,7 +113,7 @@ static ssize_t console_log_read(struct console_log *log, uint8_t *buf, size_t si
 	if (log->received < log->size) {
 		start = 0;
 	} else {
-		start = log->allocated - log->size;
+		start = log->received - log->size;
 	}
 
 	if (start > pos)
@@ -183,26 +140,22 @@ out:
 
 static ssize_t console_log_write(struct console_log *log, const uint8_t *buf, size_t size)
 {
-	size_t copied = 0;
+	k_mutex_lock(&log->tx_mutex, K_FOREVER);
 
-	while (copied < size) {
-		size_t len = MIN(size - copied, UART_TX_BUF_SIZE);
-		int ret;
+	log->tx_buf = buf;
+	log->tx_len = size;
+	log->tx_pos = 0;
+	k_sem_reset(&log->tx_done);
 
-		k_sem_take(&log->tx_sem, K_FOREVER);
-		memcpy(log->tx_buffer, buf + copied, len);
+	uart_irq_tx_enable(log->uart);
+	k_sem_take(&log->tx_done, K_FOREVER);
 
-		ret = uart_tx(log->uart, log->tx_buffer, len, SYS_FOREVER_US);
-		if (ret < 0) {
-			LOG_WRN("UART TX error: %d", ret);
-			k_sem_give(&log->tx_sem);
-			return copied ? copied : ret;
-		}
+	log->tx_buf = NULL;
+	log->tx_len = 0;
+	log->tx_pos = 0;
 
-		copied += len;
-	}
-
-	return copied;
+	k_mutex_unlock(&log->tx_mutex);
+	return size;
 }
 
 ssize_t host_console_read(uint8_t *buf, size_t size, uint64_t *ppos)
@@ -253,9 +206,9 @@ int console_logger_init(void)
 	memset(log, 0, sizeof(struct console_log));
 	log->uart = uart_dev;
 	log->size = sizeof(log_buffer);
-	k_sem_init(&log->tx_sem, 1, 1);
+	k_mutex_init(&log->tx_mutex);
+	k_sem_init(&log->tx_done, 0, 1);
 	log->log_buffer = log_buffer;
-	log->tx_buffer = tx_buffer;
 
 #if DT_NODE_EXISTS(UARTMUXSEL_NODE)
 	/* Initialize host_console_uart_muxsel GPIO */
@@ -276,22 +229,19 @@ int console_logger_init(void)
 
 	ret = uart_configure(uart_dev, &uart_cfg);
 	if (ret < 0) {
-		LOG_ERR("Configuration is not supported by device or driver,"
-			" check the UART settings configuration");
+		LOG_ERR("UART configure failed: %d", ret);
 		return -1;
 	}
 
-	/* Set up UART callback for async RX */
-	ret = uart_callback_set(uart_dev, uart_callback, log);
+	ret = uart_irq_callback_user_data_set(uart_dev, uart_isr_cb, log);
 	if (ret < 0) {
-		LOG_ERR("Failed to set UART callback: %d", ret);
+		LOG_ERR("Failed to set UART IRQ callback: %d", ret);
 		return ret;
 	}
 
-	/* Enable UART RX to start receiving data */
-	uart_rx_start(uart_dev, log);
+	uart_irq_rx_enable(uart_dev);
 
-	LOG_INF("UART callback configured for console logger");
+	LOG_INF("UART IRQ configured for console logger");
 
 	return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -65,6 +65,7 @@ static void print_banner(void)
 
 FUNC_NORETURN int bmc_reboot(void)
 {
+	wifi_shutdown();
 	fs_exit();
 
 	LOG_WRN("Rebooting BMC");

--- a/src/main.c
+++ b/src/main.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(wallabmc, LOG_LEVEL_INF);
 #include "config.h"
 #include "button.h"
 #include "net.h"
+#include "wifi.h"
 #include "http.h"
 #include "power.h"
 #include "rtc.h"
@@ -228,6 +229,12 @@ int main(void)
 	if (net_init() < 0) {
 		LOG_ERR("Network init failed");
 		return -1;
+	}
+
+	LOG_DBG("Wi-Fi connect init");
+	if (wifi_connect_init() < 0) {
+		LOG_ERR("Wi-Fi connect init failed");
+		/* Continue */
 	}
 
 	LOG_DBG("Power init");

--- a/src/main.c
+++ b/src/main.c
@@ -226,16 +226,23 @@ int main(void)
 		/* Continue */
 	}
 
-	LOG_DBG("Network init");
-	if (net_init() < 0) {
-		LOG_ERR("Network init failed");
-		return -1;
-	}
-
+	/*
+	 * Wi-Fi connect must be requested before net_init(), because
+	 * net_init() blocks in net_config_init_app() waiting for the
+	 * interface to come up. On Wi-Fi boards that only happens once
+	 * association completes, so the connect request has to be in
+	 * flight first.
+	 */
 	LOG_DBG("Wi-Fi connect init");
 	if (wifi_connect_init() < 0) {
 		LOG_ERR("Wi-Fi connect init failed");
 		/* Continue */
+	}
+
+	LOG_DBG("Network init");
+	if (net_init() < 0) {
+		LOG_ERR("Network init failed");
+		/* Continue -- shell stays up so the user can `wifi connect`. */
 	}
 
 	LOG_DBG("Power init");

--- a/src/power.c
+++ b/src/power.c
@@ -15,6 +15,7 @@
 LOG_MODULE_REGISTER(wallabmc_power);
 
 #include "config.h"
+#include "power.h"
 
 #define GPIO_POWER_1 DT_ALIAS(power_gpio_1)
 #define GPIO_POWER_2 DT_ALIAS(power_gpio_2)
@@ -37,6 +38,79 @@ bool power_get_state(void)
 	return system_power_state;
 }
 
+#ifdef CONFIG_APP_HOST_POWER_PULSE
+static int power_pulse(int ms)
+{
+	int i, ret;
+
+	for (i = 0; i < ARRAY_SIZE(power_gpios); i++) {
+		ret = gpio_pin_set_dt(&power_gpios[i], 1);
+		if (ret < 0) {
+			LOG_ERR("Could not assert power GPIO %d", i);
+			return -1;
+		}
+	}
+
+	k_msleep(ms);
+
+	for (i = 0; i < ARRAY_SIZE(power_gpios); i++) {
+		ret = gpio_pin_set_dt(&power_gpios[i], 0);
+		if (ret < 0) {
+			LOG_ERR("Could not release power GPIO %d", i);
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+static int power_on(void)
+{
+	int ret;
+
+	if (system_power_state) {
+		LOG_INF("Host already on; skipping press");
+		return 0;
+	}
+
+	ret = power_pulse(CONFIG_APP_HOST_POWER_PULSE_MS);
+	if (ret < 0)
+		return ret;
+
+	system_power_state = true;
+	return 0;
+}
+
+static int power_off(void)
+{
+	int ret;
+
+	if (!system_power_state) {
+		LOG_INF("Host already off; skipping press");
+		return 0;
+	}
+
+	ret = power_pulse(CONFIG_APP_HOST_POWER_PULSE_MS);
+	if (ret < 0)
+		return ret;
+
+	system_power_state = false;
+	return 0;
+}
+
+int power_force_off(void)
+{
+	int ret;
+
+	LOG_WRN("Forcing host off (long press)");
+	ret = power_pulse(CONFIG_APP_HOST_POWER_FORCE_OFF_MS);
+	if (ret < 0)
+		return ret;
+
+	system_power_state = false;
+	return 0;
+}
+#else /* !CONFIG_APP_HOST_POWER_PULSE */
 static int power_on(void)
 {
 	int i, ret;
@@ -70,6 +144,12 @@ static int power_off(void)
 
 	return 0;
 }
+
+int power_force_off(void)
+{
+	return power_off();
+}
+#endif /* CONFIG_APP_HOST_POWER_PULSE */
 
 void power_set_state(bool on)
 {
@@ -126,9 +206,17 @@ static int cmd_power_off(const struct shell *sh, size_t argc, char **argv)
 	return power_off();
 }
 
+static int cmd_power_force_off(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+	return power_force_off();
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_power_cmds,
-	SHELL_CMD(on,    NULL, "Power on.", cmd_power_on),
-	SHELL_CMD(off,   NULL, "Power off.", cmd_power_off),
+	SHELL_CMD(on,        NULL, "Power on (short press).",  cmd_power_on),
+	SHELL_CMD(off,       NULL, "Power off (short press).", cmd_power_off),
+	SHELL_CMD(force-off, NULL, "Force off (long press).",  cmd_power_force_off),
 	SHELL_SUBCMD_SET_END
 );
 
@@ -155,15 +243,14 @@ int reset_init(void)
 		return -1;
 	}
 
-	ret = gpio_pin_configure_dt(&gpio_reset, GPIO_OUTPUT_ACTIVE);
+	/*
+	 * Start inactive so the pin is hi-Z (open-drain) / driven inactive
+	 * at boot. GPIO_OUTPUT_ACTIVE would briefly assert reset to the host
+	 * every time the BMC starts up.
+	 */
+	ret = gpio_pin_configure_dt(&gpio_reset, GPIO_OUTPUT_INACTIVE);
 	if (ret < 0) {
 		LOG_INF("Could not configure reset GPIO\n");
-		return -1;
-	}
-
-	ret = gpio_pin_set_dt(&gpio_reset, 0);
-	if (ret < 0) {
-		LOG_INF("Could not toggle reset GPIO\n");
 		return -1;
 	}
 

--- a/src/power.c
+++ b/src/power.c
@@ -213,10 +213,18 @@ static int cmd_power_force_off(const struct shell *sh, size_t argc, char **argv)
 	return power_force_off();
 }
 
+static int cmd_power_force_restart(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+	return power_reset();
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_power_cmds,
-	SHELL_CMD(on,        NULL, "Power on (short press).",  cmd_power_on),
-	SHELL_CMD(off,       NULL, "Power off (short press).", cmd_power_off),
-	SHELL_CMD(force-off, NULL, "Force off (long press).",  cmd_power_force_off),
+	SHELL_CMD(on,            NULL, "Power on (short press).",            cmd_power_on),
+	SHELL_CMD(off,           NULL, "Power off (short press).",           cmd_power_off),
+	SHELL_CMD(force-off,     NULL, "Force off (long press).",            cmd_power_force_off),
+	SHELL_CMD(force-restart, NULL, "Force restart (1 s low pulse).",     cmd_power_force_restart),
 	SHELL_SUBCMD_SET_END
 );
 

--- a/src/power.h
+++ b/src/power.h
@@ -9,8 +9,9 @@ int power_init(void);
 int reset_init(void);
 int status_led_init(void);
 
-int power_set_state(bool on);
+void power_set_state(bool on);
 bool power_get_state(void);
 int power_reset(void);
+int power_force_off(void);
 
 #endif

--- a/src/redfish.c
+++ b/src/redfish.c
@@ -1,11 +1,12 @@
 /*
  * Minimal Zephyr Redfish Implementation
- * Implements: ComputerSystem.Reset (On/ForceOff/PowerCycle)
+ * Implements: ComputerSystem.Reset (On/ForceOff/PowerCycle/ForceRestart)
  *
  * redfishtool Systems -r 192.168.2.55 -vvv -I system
  * redfishtool Systems -r 192.168.2.55 -vvv reset On
  * redfishtool Systems -r 192.168.2.55 -vvv reset ForceOff
  * redfishtool Systems -r 192.168.2.55 -vvv reset PowerCycle
+ * redfishtool Systems -r 192.168.2.55 -vvv reset ForceRestart
  *
  * SPDX-FileCopyrightText: © 2025-2026 Tenstorrent USA, Inc.
  * SPDX-License-Identifier: Apache-2.0
@@ -1240,14 +1241,14 @@ static char serial_number[] = "12345";
 /* System Info: ResetType array */
 struct redfish_reset_action {
 	const char *target;
-	const char *reset_type_values[3];
+	const char *reset_type_values[4];
 	size_t reset_type_values_len;
 };
 static const struct json_obj_descr reset_action_descr[] = {
 	JSON_OBJ_DESCR_PRIM(struct redfish_reset_action, target, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_ARRAY_NAMED(struct redfish_reset_action,
 				   "ResetType@Redfish.AllowableValues",
-				   reset_type_values, 3, reset_type_values_len,
+				   reset_type_values, 4, reset_type_values_len,
 				   JSON_TOK_STRING),
 };
 
@@ -1429,9 +1430,10 @@ static int system_get_handler(struct http_resource_user_data *user_data)
 				.reset_type_values = {
 					"On",
 					"ForceOff",
-					"PowerCycle"
+					"PowerCycle",
+					"ForceRestart"
 				},
-				.reset_type_values_len = 3
+				.reset_type_values_len = 4
 			}
 		}
 	};
@@ -1480,6 +1482,8 @@ static int system_reset_post_handler(struct http_resource_user_data *user_data)
 	} else if (strcmp(payload.reset_type, "ForceOff") == 0) {
 		power_set_state(false);
 	} else if (strcmp(payload.reset_type, "PowerCycle") == 0) {
+		power_reset();
+	} else if (strcmp(payload.reset_type, "ForceRestart") == 0) {
 		power_reset();
 	} else {
 		LOG_ERR("ComputerSystem.Reset: Bad reset type");

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -12,7 +12,7 @@ int time_set_from_iso_str(const char *str);
 #else /* defined(CONFIG_RTC) */
 static inline int rtc_init(void) { return 0; }
 static inline int rtc_set_from_clock(void) { return -ENODEV; }
-static inline int time_set_from_iso_str(void) { return -ENODEV; }
+static inline int time_set_from_iso_str(const char *str) { return -ENODEV; }
 #endif /* defined(CONFIG_RTC) */
 
 #endif /* __RTC_H__ */

--- a/src/wifi.c
+++ b/src/wifi.c
@@ -1,0 +1,69 @@
+/* Wi-Fi station bring-up using compile-time credentials. */
+
+/*
+ * SPDX-FileCopyrightText: © 2025-2026 Tenstorrent USA, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(wallabmc_wifi, LOG_LEVEL_INF);
+
+#include <errno.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_mgmt.h>
+#include <zephyr/net/wifi_mgmt.h>
+
+#include "wifi.h"
+
+#define WIFI_MGMT_EVENTS (NET_EVENT_WIFI_CONNECT_RESULT | \
+			  NET_EVENT_WIFI_DISCONNECT_RESULT)
+
+static struct net_mgmt_event_callback wifi_cb;
+
+static void wifi_event_handler(struct net_mgmt_event_callback *cb,
+			       uint64_t mgmt_event,
+			       struct net_if *iface)
+{
+	const struct wifi_status *status = cb->info;
+
+	ARG_UNUSED(iface);
+
+	switch (mgmt_event) {
+	case NET_EVENT_WIFI_CONNECT_RESULT:
+		if (status && status->status) {
+			LOG_ERR("Wi-Fi connect failed (status=%d)", status->status);
+		} else {
+			LOG_INF("Wi-Fi connected");
+		}
+		break;
+	case NET_EVENT_WIFI_DISCONNECT_RESULT:
+		LOG_WRN("Wi-Fi disconnected");
+		break;
+	default:
+		break;
+	}
+}
+
+int wifi_connect_init(void)
+{
+	struct net_if *iface = net_if_get_first_wifi();
+	int rc;
+
+	if (!iface) {
+		LOG_ERR("No Wi-Fi interface found");
+		return -ENODEV;
+	}
+
+	net_mgmt_init_event_callback(&wifi_cb, wifi_event_handler,
+				     WIFI_MGMT_EVENTS);
+	net_mgmt_add_event_callback(&wifi_cb);
+
+	rc = net_mgmt(NET_REQUEST_WIFI_CONNECT_STORED, iface, NULL, 0);
+	if (rc) {
+		LOG_ERR("Wi-Fi connect-stored request failed (rc=%d)", rc);
+		return rc;
+	}
+
+	LOG_INF("Wi-Fi connect requested; waiting for association...");
+	return 0;
+}

--- a/src/wifi.c
+++ b/src/wifi.c
@@ -47,6 +47,9 @@ static void wifi_event_handler(struct net_mgmt_event_callback *cb,
 int wifi_connect_init(void)
 {
 	struct net_if *iface = net_if_get_first_wifi();
+	struct wifi_ps_params ps = {
+		.enabled = WIFI_PS_DISABLED,
+	};
 	int rc;
 
 	if (!iface) {
@@ -57,6 +60,16 @@ int wifi_connect_init(void)
 	net_mgmt_init_event_callback(&wifi_cb, wifi_event_handler,
 				     WIFI_MGMT_EVENTS);
 	net_mgmt_add_event_callback(&wifi_cb);
+
+	/*
+	 * The ESP32 driver enables WIFI_PS_MAX_MODEM by default, which causes
+	 * 100+ ms RX latency spikes and dropped frames under bursty HTTP load.
+	 * The BMC is mains-powered, so trade the power saving for reliability.
+	 */
+	rc = net_mgmt(NET_REQUEST_WIFI_PS, iface, &ps, sizeof(ps));
+	if (rc) {
+		LOG_WRN("Could not disable Wi-Fi power save (rc=%d)", rc);
+	}
 
 	rc = net_mgmt(NET_REQUEST_WIFI_CONNECT_STORED, iface, NULL, 0);
 	if (rc) {

--- a/src/wifi.c
+++ b/src/wifi.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(wallabmc_wifi, LOG_LEVEL_INF);
 			  NET_EVENT_WIFI_DISCONNECT_RESULT)
 
 static struct net_mgmt_event_callback wifi_cb;
+static K_SEM_DEFINE(wifi_disconnected_sem, 0, 1);
 
 static void wifi_event_handler(struct net_mgmt_event_callback *cb,
 			       uint64_t mgmt_event,
@@ -38,6 +39,7 @@ static void wifi_event_handler(struct net_mgmt_event_callback *cb,
 		break;
 	case NET_EVENT_WIFI_DISCONNECT_RESULT:
 		LOG_WRN("Wi-Fi disconnected");
+		k_sem_give(&wifi_disconnected_sem);
 		break;
 	default:
 		break;
@@ -79,4 +81,34 @@ int wifi_connect_init(void)
 
 	LOG_INF("Wi-Fi connect requested; waiting for association...");
 	return 0;
+}
+
+void wifi_shutdown(void)
+{
+	struct net_if *iface = net_if_get_first_wifi();
+	int rc;
+
+	if (!iface)
+		return;
+
+	/*
+	 * sys_reboot() on ESP32 leaves the Wi-Fi MAC/AP-side association in
+	 * a state where the next boot sometimes fails to re-associate (board
+	 * stays unreachable, no DHCP). Disassociate, wait for the driver to
+	 * confirm via NET_EVENT_WIFI_DISCONNECT_RESULT, then take the iface
+	 * down so the AP drops us cleanly before the reset.
+	 */
+	k_sem_reset(&wifi_disconnected_sem);
+	rc = net_mgmt(NET_REQUEST_WIFI_DISCONNECT, iface, NULL, 0);
+	if (rc && rc != -EALREADY) {
+		LOG_WRN("Wi-Fi disconnect request failed (rc=%d)", rc);
+	} else if (rc == 0) {
+		(void)k_sem_take(&wifi_disconnected_sem, K_MSEC(1000));
+	}
+
+	rc = net_if_down(iface);
+	if (rc && rc != -EALREADY) {
+		LOG_WRN("Wi-Fi iface down failed (rc=%d)", rc);
+	}
+	k_msleep(200);
 }

--- a/src/wifi.c
+++ b/src/wifi.c
@@ -8,11 +8,14 @@
 LOG_MODULE_REGISTER(wallabmc_wifi, LOG_LEVEL_INF);
 
 #include <errno.h>
+#include <string.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/wifi_mgmt.h>
+#include <zephyr/shell/shell.h>
 
+#include "config.h"
 #include "wifi.h"
 
 #define WIFI_MGMT_EVENTS (NET_EVENT_WIFI_CONNECT_RESULT | \
@@ -46,12 +49,54 @@ static void wifi_event_handler(struct net_mgmt_event_callback *cb,
 	}
 }
 
+/*
+ * Connect using a runtime-supplied SSID/password pair, bypassing the
+ * compile-time CONFIG_WIFI_CREDENTIALS_STATIC entry in the
+ * wifi_credentials store. Used at boot when the user has saved
+ * credentials via `wifi connect`, and from the shell command itself.
+ *
+ * We avoid wifi_credentials_set_personal() + NET_REQUEST_WIFI_CONNECT_STORED
+ * here because that path also re-adds the static entry whenever the
+ * stored SSID does not match it, which races with our update on the
+ * ESP32-C6 build and intermittently wedges Wi-Fi association after a
+ * disconnect+reconnect.
+ */
+static int wifi_connect_with(struct net_if *iface, const char *ssid, const char *password)
+{
+	static uint8_t ssid_buf[WIFI_SSID_MAX_LEN + 1];
+	static uint8_t psk_buf[WIFI_PSK_MAX_LEN + 1];
+	struct wifi_connect_req_params params = {
+		.ssid = ssid_buf,
+		.psk = psk_buf,
+	};
+	size_t ssid_len = strlen(ssid);
+	size_t psk_len = strlen(password);
+
+	if (ssid_len == 0 || ssid_len > WIFI_SSID_MAX_LEN)
+		return -EINVAL;
+	if (psk_len > WIFI_PSK_MAX_LEN)
+		return -EINVAL;
+
+	memcpy(ssid_buf, ssid, ssid_len);
+	params.ssid_length = ssid_len;
+	memcpy(psk_buf, password, psk_len);
+	params.psk_length = psk_len;
+	params.security = (psk_len > 0) ? WIFI_SECURITY_TYPE_PSK : WIFI_SECURITY_TYPE_NONE;
+	params.channel = WIFI_CHANNEL_ANY;
+	params.band = WIFI_FREQ_BAND_UNKNOWN;
+	params.mfp = WIFI_MFP_OPTIONAL;
+	params.timeout = SYS_FOREVER_MS;
+
+	return net_mgmt(NET_REQUEST_WIFI_CONNECT, iface, &params, sizeof(params));
+}
+
 int wifi_connect_init(void)
 {
 	struct net_if *iface = net_if_get_first_wifi();
 	struct wifi_ps_params ps = {
 		.enabled = WIFI_PS_DISABLED,
 	};
+	const char *ssid = config_wifi_ssid();
 	int rc;
 
 	if (!iface) {
@@ -71,6 +116,17 @@ int wifi_connect_init(void)
 	rc = net_mgmt(NET_REQUEST_WIFI_PS, iface, &ps, sizeof(ps));
 	if (rc) {
 		LOG_WRN("Could not disable Wi-Fi power save (rc=%d)", rc);
+	}
+
+	if (ssid[0] != '\0') {
+		LOG_INF("Connecting to stored Wi-Fi SSID: %s", ssid);
+		rc = wifi_connect_with(iface, ssid, config_wifi_password());
+		if (rc) {
+			LOG_ERR("Wi-Fi connect request failed (rc=%d)", rc);
+			return rc;
+		}
+		LOG_INF("Wi-Fi connect requested; waiting for association...");
+		return 0;
 	}
 
 	rc = net_mgmt(NET_REQUEST_WIFI_CONNECT_STORED, iface, NULL, 0);
@@ -112,3 +168,100 @@ void wifi_shutdown(void)
 	}
 	k_msleep(200);
 }
+
+static int cmd_wifi_connect(const struct shell *sh, size_t argc, char **argv)
+{
+	struct net_if *iface = net_if_get_first_wifi();
+	const char *ssid;
+	const char *password;
+	int rc;
+
+	ARG_UNUSED(argc);
+
+	ssid = argv[1];
+	password = argv[2];
+
+	if (!iface) {
+		shell_error(sh, "No Wi-Fi interface found");
+		return -ENODEV;
+	}
+
+	rc = config_wifi_set(ssid, password);
+	if (rc) {
+		shell_error(sh, "Could not save Wi-Fi credentials (err=%d)", rc);
+		return rc;
+	}
+
+	/*
+	 * Disassociate from the current AP (best effort -- ignore -EALREADY)
+	 * and wait briefly for the driver to confirm before reconnecting
+	 * with the new credentials.
+	 */
+	k_sem_reset(&wifi_disconnected_sem);
+	rc = net_mgmt(NET_REQUEST_WIFI_DISCONNECT, iface, NULL, 0);
+	if (rc == 0)
+		(void)k_sem_take(&wifi_disconnected_sem, K_MSEC(1000));
+
+	rc = wifi_connect_with(iface, ssid, password);
+	if (rc) {
+		shell_error(sh, "Wi-Fi connect failed (err=%d)", rc);
+		return rc;
+	}
+
+	shell_info(sh, "Wi-Fi credentials saved; connecting to %s", ssid);
+	return 0;
+}
+
+static int cmd_wifi_clear(const struct shell *sh, size_t argc, char **argv)
+{
+	struct net_if *iface = net_if_get_first_wifi();
+	int rc;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	rc = config_wifi_clear();
+	if (rc) {
+		shell_error(sh, "Could not clear Wi-Fi credentials (err=%d)", rc);
+		return rc;
+	}
+
+	if (iface) {
+		k_sem_reset(&wifi_disconnected_sem);
+		rc = net_mgmt(NET_REQUEST_WIFI_DISCONNECT, iface, NULL, 0);
+		if (rc == 0)
+			(void)k_sem_take(&wifi_disconnected_sem, K_MSEC(1000));
+	}
+
+	shell_info(sh, "Wi-Fi credentials cleared; not reconnecting");
+	return 0;
+}
+
+static int cmd_wifi_config(const struct shell *sh, size_t argc, char **argv)
+{
+	const char *ssid = config_wifi_ssid();
+	const char *password = config_wifi_password();
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	if (ssid[0] == '\0') {
+		shell_print(sh, "Wi-Fi: no credentials stored (use `wifi connect <ssid> <password>`)");
+	} else {
+		shell_print(sh, "Wi-Fi SSID:     %s", ssid);
+		shell_print(sh, "Wi-Fi password: %s", password);
+	}
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_wifi_cmds,
+	SHELL_CMD_ARG(connect, NULL,
+		      "Connect to a Wi-Fi network and persist the credentials.\n"
+		      "Usage: wifi connect <ssid> <password>",
+		      cmd_wifi_connect, 3, 0),
+	SHELL_CMD(clear,  NULL, "Clear the stored Wi-Fi credentials and disconnect.", cmd_wifi_clear),
+	SHELL_CMD(config, NULL, "Show the stored Wi-Fi credentials.",                  cmd_wifi_config),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_CMD_REGISTER(wifi, &sub_wifi_cmds, "Wi-Fi commands", NULL);

--- a/src/wifi.c
+++ b/src/wifi.c
@@ -129,13 +129,21 @@ int wifi_connect_init(void)
 		return 0;
 	}
 
+#if defined(CONFIG_WIFI_CREDENTIALS_CONNECT_STORED)
+	/*
+	 * NVS has no SSID; fall back to whatever is in the wifi_credentials
+	 * store (typically the compile-time CONFIG_WIFI_CREDENTIALS_STATIC
+	 * entry baked into the image).
+	 */
 	rc = net_mgmt(NET_REQUEST_WIFI_CONNECT_STORED, iface, NULL, 0);
 	if (rc) {
 		LOG_ERR("Wi-Fi connect-stored request failed (rc=%d)", rc);
 		return rc;
 	}
-
 	LOG_INF("Wi-Fi connect requested; waiting for association...");
+#else
+	LOG_WRN("No Wi-Fi credentials configured -- use `wifi connect <ssid> <password>` to set them");
+#endif
 	return 0;
 }
 

--- a/src/wifi.h
+++ b/src/wifi.h
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: © 2025-2026 Tenstorrent USA, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef __WIFI_H__
+#define __WIFI_H__
+#ifdef CONFIG_APP_WIFI
+int wifi_connect_init(void);
+#else
+static inline int wifi_connect_init(void) { return 0; }
+#endif
+#endif

--- a/src/wifi.h
+++ b/src/wifi.h
@@ -6,7 +6,9 @@
 #define __WIFI_H__
 #ifdef CONFIG_APP_WIFI
 int wifi_connect_init(void);
+void wifi_shutdown(void);
 #else
 static inline int wifi_connect_init(void) { return 0; }
+static inline void wifi_shutdown(void) { }
 #endif
 #endif


### PR DESCRIPTION
This allows reset and uart control of the K3 using the XIAO esp32 board.

ESP32 Wifi is configured via the bmc serial console (or build parameters) and stored in nvram.

This works for me. I've not tested other hardware platforms to make sure I've not regressed anything. 

Code written by Claude. 

<img width="1024" height="701" alt="image" src="https://github.com/user-attachments/assets/1e140032-3b26-4859-838c-2f5bd94d5890" />

Helps answer #27 