### PR TITLE
redfish: fix MPU fault by making resource detail structs mutable

### DIFF
--- a/src/redfish.c
+++ b/src/redfish.c
@@ -363,7 +363,7 @@ static int name##_handler(struct http_client_ctx *client,				\
 				patch_handler,						\
 				post_handler);						\
 }											\
-static const struct http_resource_detail_dynamic name##_detail = {			\
+static struct http_resource_detail_dynamic name##_detail = {				\
 	.common = {									\
 		.type = HTTP_RESOURCE_TYPE_DYNAMIC,					\
 		.bitmask_of_supported_http_methods = -1U,				\


### PR DESCRIPTION
## Summary

Zephyr's HTTP server (`subsys/net/lib/http/http_server_http1.c`, `handle_http1_request()`) unconditionally writes `detail->path_len` on every request via `get_resource_detail()`. The `REDFISH_HANDLER` macro in `src/redfish.c` declared its `http_resource_detail_dynamic` struct as `const`, which places it in read-only flash. Writing to a read-only region trips the MPU and halts the system with a Data Access Violation the first time any Redfish endpoint (e.g. `ServiceRoot`, hit first by clients discovering/logging into the API) is requested.

This isn't board-specific — it reproduces on any board whose MPU enforces flash write-protection (the normal, correct configuration). It just hadn't been caught yet, since it fires on the very first hit to any dynamic Redfish resource.

`web.c`'s static web resources (`index.html`, `logo.png`, etc.) were not affected — they already correctly declare their `http_resource_detail_static` structs without `const`. Only the Redfish dynamic-handler path had the bug.

## Fix

Drop `const` from the struct declaration in the `REDFISH_HANDLER` macro, moving it from flash to RAM, matching the pattern `web.c` already uses correctly.

## Test plan

- [x] Reproduced the crash on an NXP FRDM-MCXN947 (MPU fault, `Data Access Violation` at the resource-detail struct's `path_len` field)
- [x] Applied the fix, rebuilt, reflashed
- [x] Confirmed via live serial console and a real client login/API request from the network peer that previously crashed it — no fault, request handled normally