### PR TITLE
support for FRDM MCX-N947 board

### DIFF
--- a/boards/frdm_mcxn947_mcxn947_cpu0.conf
+++ b/boards/frdm_mcxn947_mcxn947_cpu0.conf
@@ -1,0 +1,16 @@
+# Gentoo mode
+CONFIG_SPEED_OPTIMIZATIONS=y
+
+# TODO: no board-specific persistent storage backend yet (internal flash
+# self-write requires driver relocation like the STM32 port has, or NVS
+# could target the external W25Q64 QSPI NOR flash instead). Disabled for
+# now; config.c/fs.c already fall back cleanly when this is off.
+CONFIG_PERSISTENT_STORAGE=n
+
+# Redfish system overview (board-specific)
+CONFIG_REDFISH_SYSTEM_PRODUCT_NAME="FRDM-MCXN947"
+CONFIG_REDFISH_SYSTEM_MANUFACTURER="NXP"
+CONFIG_REDFISH_SYSTEM_MODEL="FRDM-MCXN947"
+CONFIG_REDFISH_SYSTEM_PROCESSOR_MODEL="NXP MCX N947 (dual Cortex-M33)"
+CONFIG_REDFISH_SYSTEM_PROCESSOR_COUNT=1
+CONFIG_REDFISH_SYSTEM_MEMORY_GIB=0

--- a/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -1,0 +1,59 @@
+// NXP FRDM-MCXN947
+
+/ {
+	chosen {
+		zephyr,rtc = &rtc;
+	};
+
+	aliases {
+		status-led = &blue_led;
+		power-gpio-1 = &green_led;
+		reset-gpio-1 = &red_led;
+		reset-button = &user_button_2;
+
+		/*
+		 * No physical "host" is wired to this devkit. Route the
+		 * host console bridge to the Arduino-header UART
+		 * (flexcomm2_lpuart2 / D0-D1) so it's available if a real
+		 * host's serial console is wired up later.
+		 */
+		host-console-uart = &flexcomm2_lpuart2;
+	};
+};
+
+&red_led {
+	status = "okay";
+};
+
+&green_led {
+	status = "okay";
+};
+
+&blue_led {
+	status = "okay";
+};
+
+&user_button_2 {
+	status = "okay";
+};
+
+&rtc {
+	status = "okay";
+};
+
+&flexcomm2_lpuart2 {
+	status = "okay";
+};
+
+/* On-board LAN8741 PHY + RJ45 (disabled by default in the base board dts) */
+&enet_mdio {
+	status = "okay";
+};
+
+&phy {
+	status = "okay";
+};
+
+&enet_mac {
+	status = "okay";
+};

--- a/sysbuild/mcuboot/boards/frdm_mcxn947_mcxn947_cpu0.conf
+++ b/sysbuild/mcuboot/boards/frdm_mcxn947_mcxn947_cpu0.conf
@@ -1,0 +1,3 @@
+### slot0_partition is 984KB at 8KB/sector = 123 sectors
+CONFIG_BOOT_MAX_IMG_SECTORS_AUTO=n
+CONFIG_BOOT_MAX_IMG_SECTORS=123

--- a/sysbuild/mcuboot/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/sysbuild/mcuboot/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -1,0 +1,12 @@
+#include "../../../boards/frdm_mcxn947_mcxn947_cpu0.overlay"
+
+/*
+ * This comes from zephyr/bootloader/mcuboot/boot/zephyr/app.overlay
+ * Otherwise mcuboot builds using the slot0_partition which is where
+ * wallabmc lives.
+ */
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};


### PR DESCRIPTION
## Summary

Adds app and MCUboot board config/devicetree overlays for the NXP FRDM-MCXN947 (dual Cortex-M33). Enables the on-board LAN8741 Ethernet PHY, on-chip RTC, status/power LEDs, and reset button.

## Known limitations

- Persistent config storage is disabled (`CONFIG_PERSISTENT_STORAGE=n`) — internal flash self-write requires driver relocation (like the STM32 port), or NVS could target the board's external W25Q64 QSPI NOR flash instead. `config.c`/`fs.c` already fall back cleanly when this is off.
- `host-console-uart` is wired to the Arduino-header UART (`flexcomm2_lpuart2`) since there's no physical "host" wired to a devkit.

## Test plan

- [x] Built and flashed on real FRDM-MCXN947 hardware
- [x] Boots through MCUboot, interactive shell works
- [x] On-board Ethernet (LAN8741 PHY) link-up and DHCP verified on a live network
- [ ] Persistent storage not yet implemented for this board